### PR TITLE
Unknown contract

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@
  - Determine solc version using pragma, allow multiple versions in one project
  - Set EVM version in config file
  - Allow config file comments, change structure
+ - Add PublicKeyAccount and Contract (via ABI), allow tracebacks on unknown contracts
  - Expanded Alert functionality
  - Windows bugfixes
 

--- a/brownie/__init__.py
+++ b/brownie/__init__.py
@@ -11,6 +11,7 @@ from .project import (
     compile_source,
     run,
 )
+from brownie.network.contract import ContractABI  # NOQA: F401
 from brownie.gui import Gui
 from brownie._config import CONFIG as config
 from brownie.convert import Wei

--- a/brownie/__init__.py
+++ b/brownie/__init__.py
@@ -11,7 +11,7 @@ from .project import (
     compile_source,
     run,
 )
-from brownie.network.contract import ContractABI  # NOQA: F401
+from brownie.network.contract import Contract  # NOQA: F401
 from brownie.gui import Gui
 from brownie._config import CONFIG as config
 from brownie.convert import Wei

--- a/brownie/convert.py
+++ b/brownie/convert.py
@@ -174,6 +174,9 @@ class HexString(bytes):
     def __str__(self):
         return "0x" + self.hex()
 
+    def __repr__(self):
+        return str(self)
+
 
 def _hex_compare(a, b):
     b = str(b)

--- a/brownie/exceptions.py
+++ b/brownie/exceptions.py
@@ -77,6 +77,10 @@ class ContractExists(Exception):
     pass
 
 
+class ContractNotFound(Exception):
+    pass
+
+
 class ProjectAlreadyLoaded(Exception):
     pass
 

--- a/brownie/network/account.py
+++ b/brownie/network/account.py
@@ -190,7 +190,7 @@ class _AccountBase:
         balance = web3.eth.getBalance(self.address)
         return Wei(balance)
 
-    def deploy(self, contract, *args, amount=None, gas_limit=None, gas_price=None, callback=None):
+    def deploy(self, contract, *args, amount=None, gas_limit=None, gas_price=None):
         '''Deploys a contract.
 
         Args:
@@ -202,7 +202,6 @@ class _AccountBase:
             amount: Amount of ether to send with transaction, in wei.
             gas_limit: Gas limit of the transaction.
             gas_price: Gas price of the transaction.
-            callback: Callback function to attach to TransactionReceipt.
 
         Returns:
             * Contract instance if the transaction confirms
@@ -230,7 +229,6 @@ class _AccountBase:
             txid,
             self,
             name=contract._name + ".constructor",
-            callback=callback,
             revert=revert
         )
         if tx.status != 1:

--- a/brownie/network/alert.py
+++ b/brownie/network/alert.py
@@ -20,16 +20,7 @@ class Alert:
     '''Setup notifications and callbacks based on state changes to the blockchain.
     The alert is immediatly active as soon as the class is insantiated.'''
 
-    def __init__(
-        self,
-        fn,
-        args=None,
-        kwargs=None,
-        delay=0.5,
-        msg=None,
-        callback=None,
-        repeat=False
-    ):
+    def __init__(self, fn, args=None, kwargs=None, delay=2, msg=None, callback=None, repeat=False):
         '''Creates a new Alert.
 
         Args:

--- a/brownie/network/history.py
+++ b/brownie/network/history.py
@@ -121,6 +121,8 @@ def _remove_contract(contract):
 # RPC registry methods
 
 def _reset():
+    for contract in _contract_map.values():
+        contract._reverted = True
     _contract_map.clear()
 
 
@@ -130,4 +132,5 @@ def _revert(height):
             continue
         if len(web3.eth.getCode(contract.address).hex()) > 4:
             continue
+        _contract_map[address]._reverted = True
         del _contract_map[address]

--- a/brownie/network/rpc.py
+++ b/brownie/network/rpc.py
@@ -276,12 +276,3 @@ class Rpc(metaclass=_Singleton):
                 obj._revert(height)
             else:
                 obj._reset()
-
-
-def _win_proc_filter(proc, match):
-    try:
-        cmdline = " ".join(proc.cmdline())
-    except psutil.AccessDenied:
-        return False
-    match = ["node"] + match.split()
-    return not [i for i in match if i not in cmdline]

--- a/brownie/network/transaction.py
+++ b/brownie/network/transaction.py
@@ -69,6 +69,7 @@ class TransactionReceipt:
         '_getattr',
         '_trace',
         '_revert_pc',
+        '_confirmed',
         'block_number',
         'contract_address',
         'contract_name',
@@ -111,6 +112,7 @@ class TransactionReceipt:
 
         self._getattr = False
         self._trace = None
+        self._confirmed = threading.Event()
         self.sender = sender
         self.status = -1
         self.txid = txid
@@ -201,6 +203,7 @@ class TransactionReceipt:
         # await confirmation
         receipt = web3.eth.waitForTransactionReceipt(self.txid, None)
         self._set_from_receipt(receipt)
+        self._confirmed.set()
         if not silent:
             print(self._confirm_output())
 

--- a/brownie/network/transaction.py
+++ b/brownie/network/transaction.py
@@ -93,7 +93,7 @@ class TransactionReceipt:
         'value',
     )
 
-    def __init__(self, txid, sender=None, silent=False, name='', callback=None, revert=None):
+    def __init__(self, txid, sender=None, silent=False, name='', revert=None):
         '''Instantiates a new TransactionReceipt object.
 
         Args:
@@ -101,7 +101,6 @@ class TransactionReceipt:
             sender: sender as a hex string or Account object
             silent: toggles console verbosity
             name: contract function being called
-            callback: optional callback function
             revert: (revert string, program counter)
         '''
         if type(txid) is not str:
@@ -134,7 +133,7 @@ class TransactionReceipt:
         # threaded to allow impatient users to ctrl-c to stop waiting in the console
         confirm_thread = threading.Thread(
             target=self._await_confirmation,
-            args=(silent, callback),
+            args=(silent,),
             daemon=True
         )
         confirm_thread.start()
@@ -180,7 +179,7 @@ class TransactionReceipt:
         finally:
             self._getattr = False
 
-    def _await_confirmation(self, silent, callback):
+    def _await_confirmation(self, silent):
 
         # await tx showing in mempool
         while True:
@@ -204,8 +203,6 @@ class TransactionReceipt:
         self._set_from_receipt(receipt)
         if not silent:
             print(self._confirm_output())
-        if callback:
-            callback(self)
 
     def _set_from_tx(self, tx):
         if not self.sender:

--- a/brownie/network/transaction.py
+++ b/brownie/network/transaction.py
@@ -692,9 +692,10 @@ def _get_last_map(address, sig):
         last_map.update({
             'contract': contract,
             'name': contract._name,
-            'fn': [f"{contract._name}.{contract.get_method(sig)}"],
-            'pc_map': contract._build['pcMap']
+            'fn': [f"{contract._name}.{contract.get_method(sig)}"]
         })
+        if contract._build:
+            last_map['pc_map'] = contract._build['pcMap']
     else:
         last_map.update({'contract': None, 'fn': [f"<UnknownContract>.{sig}"]})
     return last_map

--- a/brownie/network/transaction.py
+++ b/brownie/network/transaction.py
@@ -18,7 +18,7 @@ from .event import (
     decode_trace
 )
 from .web3 import Web3
-from brownie.convert import Wei
+from brownie.convert import EthAddress, Wei
 from brownie.cli.utils import color
 from brownie.exceptions import RPCRequestError, VirtualMachineError
 from brownie.project import build
@@ -209,8 +209,8 @@ class TransactionReceipt:
 
     def _set_from_tx(self, tx):
         if not self.sender:
-            self.sender = tx['from']
-        self.receiver = tx['to']
+            self.sender = EthAddress(tx['from'])
+        self.receiver = EthAddress(tx['to']) if tx['to'] else None
         self.value = Wei(tx['value'])
         self.gas_price = tx['gasPrice']
         self.gas_limit = tx['gas']
@@ -684,7 +684,7 @@ def _raise(msg, source):
 def _get_last_map(address, sig):
     contract = find_contract(address)
     last_map = {
-        'address': address,
+        'address': EthAddress(address),
         'jumpDepth': 0,
         'name': None,
     }

--- a/docs/api-brownie.rst
+++ b/docs/api-brownie.rst
@@ -266,6 +266,16 @@ The ``exceptions`` module contains all Brownie ``Exception`` classes.
 network
 *******
 
+.. py:exception:: brownie.exceptions.ContractExists
+
+    Raised when attempting to create a new ``Contract`` or ``ContractABI`` object, when one already exists for the given address.
+
+    Raised by ``project.compile_source`` when the source code contains a contract with a name that is the same as another in the same project.
+
+.. py:exception:: brownie.exceptions.ContractNotFound
+
+    Raised when attempting to access a ``Contract`` or ``ContractABI`` object that no longer exists because the local network was reverted.
+
 .. py:exception:: brownie.exceptions.UnknownAccount
 
     Raised when the ``Accounts`` container cannot locate a specified ``Account`` object.
@@ -296,10 +306,6 @@ network
 
 project
 *******
-
-.. py:exception:: brownie.exceptions.ContractExists
-
-    Raised by ``project.compile_source`` when the source code contains a contract with a name that is the same as a contract in the active project.
 
 .. py:exception:: brownie.exceptions.ProjectAlreadyLoaded
 

--- a/docs/api-network.rst
+++ b/docs/api-network.rst
@@ -224,7 +224,7 @@ Account Methods
         >>> accounts[0].balance() == "100 ether"
         True
 
-.. py:classmethod:: Account.deploy(contract, *args, amount=None, gas_limit=None, gas_price=None, callback=None)
+.. py:classmethod:: Account.deploy(contract, *args, amount=None, gas_limit=None, gas_price=None)
 
     Deploys a contract.
 
@@ -499,9 +499,11 @@ Module Methods
 ``brownie.network.contract``
 ============================
 
-The ``contract`` module contains classes for interacting with smart contracts.
+The ``contract`` module contains classes for deploying and interacting with smart contracts.
 
-Classes in this module are not meant to be instantiated directly. When a project is loaded, Brownie automatically creates ``ContractContainer`` instances from on the files in the ``contracts/`` folder. New ``Contract`` instances are created via methods in the container.
+When a project is loaded, Brownie automatically creates ``ContractContainer`` instances from on the files in the ``contracts/`` folder. New ``ProjectContract`` instances are created via methods in the container.
+
+If you wish to interact with a contract outside of a project where only the ABI is available, use the ``Contract`` class.
 
 Arguments supplied to calls or transaction methods are converted using the methods outlined in the :ref:`convert<api-brownie-convert>` module.
 
@@ -512,7 +514,7 @@ ContractContainer
 
 .. py:class:: brownie.network.contract.ContractContainer
 
-    A list-like container class that holds all ``Contract`` instances of the same type, and is used to deploy new instances of that contract.
+    A list-like container class that holds all ``ProjectContract`` instances of the same type, and is used to deploy new instances of that contract.
 
     .. code-block:: python
 
@@ -593,7 +595,7 @@ ContractContainer Methods
 
     If the contract requires a library, the most recently deployed one will be used. If the required library has not been deployed yet an ``IndexError`` is raised.
 
-    Returns a ``Contract`` instance upon success.
+    Returns a ``ProjectContract`` object upon success.
 
     In the console if the transaction reverts or you do not wait for a confirmation, a ``TransactionReceipt`` is returned instead.
 
@@ -619,7 +621,7 @@ ContractContainer Methods
 
 .. py:classmethod:: ContractContainer.at(address, owner=None)
 
-    Returns a ``Contract`` instance.
+    Returns a ``ProjectContract`` instance.
 
     * ``address``: Address where the contract is deployed. Raises a ValueError if there is no bytecode at the address.
     * ``owner``: ``Account`` instance to set as the contract owner. If transactions to the contract do not specify a ``'from'`` value, they will be sent from this account.
@@ -669,12 +671,30 @@ ContractContainer Methods
 
 .. _api-network-contract:
 
-Contract
---------
 
-.. py:class:: brownie.network.contract.Contract
+Contract and ProjectContract
+----------------------------
+
+``Contract`` and ``ProjectContract`` are both used to call or send transactions to smart contracts.
+
+* ``Contract`` objects are instantiated directly and only require an ABI. They are used for calls to existing contracts that exist outside of a project.
+* ``ProjectContract`` objects are created by calls to ``ContractContainer.deploy``. Because they are compiled and deployed directly by Brownie, they provide much greater debugging capability.
+
+These classes have identical APIs.
+
+.. py:class:: brownie.network.contract.Contract(address, name, abi, owner=None)
 
     A deployed contract. This class allows you to call or send transactions to the contract.
+
+    .. code-block:: python
+
+        >>> from brownie import Contract
+        >>> Contract('0x79447c97b6543F6eFBC91613C655977806CB18b0', "Token", abi)
+        <Token Contract object '0x79447c97b6543F6eFBC91613C655977806CB18b0'>
+
+.. py:class:: brownie.network.contract.ProjectContract
+
+    A deployed contract that is part of an active Brownie project. Along with making calls and transactions, this object allows access to Brownie's full range of debugging and testing capability.
 
     .. code-block:: python
 
@@ -1224,7 +1244,9 @@ Module Methods
 
 .. py:method:: brownie.network.history.find_contract(address)
 
-    Given an address, returns the related ``Contract`` object. If none exists, returns ``None``.
+    Given an address, returns the related ``Contract`` or ``ProjectContract`` object. If none exists, returns ``None``.
+
+    This method is used internally by Brownie to locate a ``ProjectContract`` when the project it belongs to is unknown.
 
 .. py:method:: brownie.network.history.get_current_dependencies()
 
@@ -1423,7 +1445,7 @@ TransactionReceipt
 
     An instance of this class is returned whenever a transaction is broadcasted. When printed in the console, the transaction hash will appear yellow if the transaction is still pending or red if the transaction caused the EVM to revert.
 
-    Many of the attributes will be set to ``None`` while the transaction is still pending.
+    Many of the attributes return ``None`` while the transaction is still pending.
 
     .. code-block:: python
 
@@ -1455,7 +1477,7 @@ TransactionReceipt Attributes
 
 .. py:attribute:: TransactionReceipt.contract_address
 
-    The address of the contract deployed as a result of this transaction, if any. If the contract is known, this will be a ``Contract`` object.
+    The address of the contract deployed as a result of this transaction, if any.
 
     .. code-block:: python
 
@@ -1609,7 +1631,7 @@ TransactionReceipt Attributes
 
     The value returned from the called function, if any. Only available if the RPC client allows ``debug_traceTransaction``.
 
-    If more then one value was returned, they are stored in a :ref:`ReturnValue<return_value>`.
+    If more then one value is returned, they are stored in a :ref:`ReturnValue<return_value>`.
 
     .. code-block:: python
 

--- a/docs/api-network.rst
+++ b/docs/api-network.rst
@@ -379,7 +379,7 @@ Alert
 
 Alerts and callbacks are handled by creating instances of the ``Alert`` class.
 
-.. py:class:: brownie.network.alert.Alert(fn, args=[], kwargs={}, delay=0.5, msg=None, callback=None, repeat=False)
+.. py:class:: brownie.network.alert.Alert(fn, args=None, kwargs=None, delay=2, msg=None, callback=None, repeat=False)
 
     An alert object. It is active immediately upon creation of the instance.
 
@@ -440,7 +440,6 @@ Alerts and callbacks are handled by creating instances of the ``Alert`` class.
 
         >>> a.is_alive()
         True
-
 
 .. py:classmethod:: Alert.wait(timeout=None)
 

--- a/tests/network/account/test_account_deploy.py
+++ b/tests/network/account/test_account_deploy.py
@@ -6,14 +6,14 @@ from brownie.exceptions import (
     VirtualMachineError,
     IncompatibleEVMVersion,
 )
-from brownie.network.contract import Contract
+from brownie.network.contract import ProjectContract
 from brownie.network.transaction import TransactionReceipt
 
 
 def test_returns_contract_on_success(BrownieTester, accounts):
     '''returns a Contract instance on successful deployment'''
     c = accounts[0].deploy(BrownieTester, True)
-    assert type(c) == Contract
+    assert type(c) == ProjectContract
 
 
 def test_raises_on_revert(BrownieTester, accounts):

--- a/tests/network/contract/test_contract.py
+++ b/tests/network/contract/test_contract.py
@@ -6,11 +6,11 @@ import pytest
 from brownie import Wei
 from brownie.network.contract import (
     _DeployedContractBase,
-    ContractABI,
     Contract,
     ContractCall,
     ContractTx,
     OverloadedMethod,
+    ProjectContract,
 )
 from brownie.exceptions import (
     ContractExists,
@@ -25,7 +25,7 @@ def build(testproject):
 
 
 def test_type(tester):
-    assert type(tester) is Contract
+    assert type(tester) is ProjectContract
     assert isinstance(tester, _DeployedContractBase)
 
 
@@ -44,7 +44,7 @@ def test_namespace_collision(tester, build):
         'type': 'function'
     })
     with pytest.raises(AttributeError):
-        ContractABI(tester.address, None, build['abi'])
+        Contract(tester.address, None, build['abi'])
 
 
 def test_overloaded(testproject, tester, build):
@@ -62,7 +62,7 @@ def test_overloaded(testproject, tester, build):
         'type': 'function'
     })
     del testproject.BrownieTester[0]
-    c = ContractABI(tester.address, None, build['abi'])
+    c = Contract(tester.address, None, build['abi'])
     fn = c.revertStrings
     assert type(fn) == OverloadedMethod
     assert len(fn) == 2
@@ -95,7 +95,7 @@ def test_comparison(testproject, tester):
     del testproject.BrownieTester[0]
     assert tester != 123
     assert tester == str(tester.address)
-    assert tester == ContractABI(tester.address, "BrownieTester", tester.abi)
+    assert tester == Contract(tester.address, "BrownieTester", tester.abi)
     repr(tester)
 
 
@@ -107,7 +107,7 @@ def test_revert_not_found(tester, rpc):
 
 def test_contractabi_replace_contract(testproject, tester):
     with pytest.raises(ContractExists):
-        ContractABI(tester.address, "BrownieTester", tester.abi)
+        Contract(tester.address, "BrownieTester", tester.abi)
     del testproject.BrownieTester[0]
-    ContractABI(tester.address, "BrownieTester", tester.abi)
-    ContractABI(tester.address, "BrownieTester", tester.abi)
+    Contract(tester.address, "BrownieTester", tester.abi)
+    Contract(tester.address, "BrownieTester", tester.abi)

--- a/tests/network/contract/test_contract.py
+++ b/tests/network/contract/test_contract.py
@@ -5,10 +5,16 @@ import pytest
 
 from brownie import Wei
 from brownie.network.contract import (
+    _DeployedContractBase,
+    ContractABI,
     Contract,
     ContractCall,
     ContractTx,
     OverloadedMethod,
+)
+from brownie.exceptions import (
+    ContractExists,
+    ContractNotFound
 )
 
 
@@ -18,7 +24,12 @@ def build(testproject):
     yield deepcopy(build)
 
 
-def test_namespace_collision(accounts, build):
+def test_type(tester):
+    assert type(tester) is Contract
+    assert isinstance(tester, _DeployedContractBase)
+
+
+def test_namespace_collision(tester, build):
     build['abi'].append({
         'constant': False,
         'inputs': [
@@ -33,10 +44,10 @@ def test_namespace_collision(accounts, build):
         'type': 'function'
     })
     with pytest.raises(AttributeError):
-        Contract(None, build, str(accounts[1]), None)
+        ContractABI(tester.address, None, build['abi'])
 
 
-def test_overloaded(accounts, build):
+def test_overloaded(testproject, tester, build):
     build['abi'].append({
         'constant': False,
         'inputs': [
@@ -50,7 +61,8 @@ def test_overloaded(accounts, build):
         'stateMutability': 'nonpayable',
         'type': 'function'
     })
-    c = Contract(None, build, str(accounts[1]), None)
+    del testproject.BrownieTester[0]
+    c = ContractABI(tester.address, None, build['abi'])
     fn = c.revertStrings
     assert type(fn) == OverloadedMethod
     assert len(fn) == 2
@@ -61,32 +73,41 @@ def test_overloaded(accounts, build):
     repr(fn)
 
 
-def test_set_methods(accounts, build):
-    c = Contract(None, build, str(accounts[1]), None)
-    for item in build['abi']:
+def test_set_methods(tester):
+    for item in tester.abi:
         if item['type'] != "function":
             if 'name' not in item:
                 continue
-            assert not hasattr(c, item['name'])
+            assert not hasattr(tester, item['name'])
         elif item['stateMutability'] in ('view', 'pure'):
-            assert type(getattr(c, item['name'])) == ContractCall
+            assert type(getattr(tester, item['name'])) == ContractCall
         else:
-            assert type(getattr(c, item['name'])) == ContractTx
+            assert type(getattr(tester, item['name'])) == ContractTx
 
 
-def test_balance(accounts, build):
-    balance = Contract(None, build, str(accounts[1]), None).balance()
+def test_balance(tester):
+    balance = tester.balance()
     assert type(balance) is Wei
-    assert balance == "100 ether"
+    assert balance == "0 ether"
 
 
-def test_comparison(accounts, build):
-    c = Contract(None, build, str(accounts[1]), None)
-    assert c != 123
-    assert c == str(accounts[1])
-    assert c != Contract(None, build, str(accounts[2]), None)
+def test_comparison(testproject, tester):
+    del testproject.BrownieTester[0]
+    assert tester != 123
+    assert tester == str(tester.address)
+    assert tester == ContractABI(tester.address, "BrownieTester", tester.abi)
+    repr(tester)
 
 
-def test_repr(accounts, build):
-    c = Contract(None, build, str(accounts[1]), None)
-    repr(c)
+def test_revert_not_found(tester, rpc):
+    rpc.reset()
+    with pytest.raises(ContractNotFound):
+        tester.balance()
+
+
+def test_contractabi_replace_contract(testproject, tester):
+    with pytest.raises(ContractExists):
+        ContractABI(tester.address, "BrownieTester", tester.abi)
+    del testproject.BrownieTester[0]
+    ContractABI(tester.address, "BrownieTester", tester.abi)
+    ContractABI(tester.address, "BrownieTester", tester.abi)

--- a/tests/network/contract/test_contractconstructor.py
+++ b/tests/network/contract/test_contractconstructor.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from brownie.network.contract import Contract
+from brownie.network.contract import ProjectContract
 from brownie.network.transaction import TransactionReceipt
 from brownie.exceptions import VirtualMachineError
 
@@ -10,7 +10,7 @@ from brownie.exceptions import VirtualMachineError
 def test_returns_contract_on_success(BrownieTester, accounts):
     '''returns a Contract instance on successful deployment'''
     c = BrownieTester.deploy(True, {'from': accounts[0]})
-    assert type(c) == Contract
+    assert type(c) == ProjectContract
 
 
 def test_raises_on_revert(BrownieTester, accounts):

--- a/tests/network/contract/test_multiple_projects.py
+++ b/tests/network/contract/test_multiple_projects.py
@@ -2,7 +2,10 @@
 
 import pytest
 
-from brownie.exceptions import VirtualMachineError
+from brownie.exceptions import (
+    ContractExists,
+    VirtualMachineError
+)
 
 
 def test_deploy(BrownieTester, otherproject, accounts):
@@ -18,7 +21,7 @@ def test_deploy(BrownieTester, otherproject, accounts):
 
 def test_at_remove(BrownieTester, otherproject, accounts):
     t = otherproject.BrownieTester.deploy(True, {'from': accounts[0]})
-    with pytest.raises(ValueError):
+    with pytest.raises(ContractExists):
         BrownieTester.at(t)
     otherproject.BrownieTester.remove(t)
     BrownieTester.at(t)

--- a/tests/network/rpc/test_weakref.py
+++ b/tests/network/rpc/test_weakref.py
@@ -11,3 +11,12 @@ def test_weakref(rpc, project, testproject, accounts):
     del o
     rpc.reset()
     assert ref_len == len(rpc._revert_refs)
+
+
+def test_weakref_deployed(rpc, project, testproject, accounts):
+    ref_len = len(rpc._revert_refs)
+    o = project.load(testproject._project_path, 'OtherProject')
+    o.BrownieTester.deploy(True, {'from': accounts[0]})
+    del o
+    rpc.reset()
+    assert ref_len == len(rpc._revert_refs)

--- a/tests/network/transaction/test_attributes.py
+++ b/tests/network/transaction/test_attributes.py
@@ -3,7 +3,6 @@
 import pytest
 
 from brownie.network.account import Account
-from brownie.network.contract import Contract
 from brownie.network.event import EventDict
 from brownie.convert import EthAddress
 from brownie import Wei
@@ -36,7 +35,7 @@ def test_receiver_contract(accounts, tester):
 def test_contract_address(accounts, tester):
     tx = accounts[0].transfer(accounts[1], "1 ether")
     assert tx.contract_address is None
-    assert type(tester.tx.contract_address) is Contract
+    assert type(tester.tx.contract_address) is str
     assert tester.tx.contract_address == tester
     assert tester.tx.receiver is None
 

--- a/tests/network/transaction/test_attributes.py
+++ b/tests/network/transaction/test_attributes.py
@@ -24,12 +24,12 @@ def test_sender_receiver(accounts):
 
 def test_receiver_contract(accounts, tester):
     tx = tester.doNothing({'from': accounts[0]})
-    assert type(tx.receiver) is Contract
-    assert tx.receiver == tester
+    assert type(tx.receiver) is str
+    assert tester == tx.receiver
     data = tester.revertStrings.encode_abi(5)
     tx = accounts[0].transfer(tester.address, 0, data=data)
-    assert type(tx.receiver) is Contract
-    assert tx.receiver == tester
+    assert type(tx.receiver) is str
+    assert tester == tx.receiver
 
 
 def test_contract_address(accounts, tester):

--- a/tests/network/transaction/test_attributes.py
+++ b/tests/network/transaction/test_attributes.py
@@ -5,6 +5,7 @@ import pytest
 from brownie.network.account import Account
 from brownie.network.contract import Contract
 from brownie.network.event import EventDict
+from brownie.convert import EthAddress
 from brownie import Wei
 
 
@@ -18,17 +19,17 @@ def test_sender_receiver(accounts):
     tx = accounts[0].transfer(accounts[1], "1 ether")
     assert type(tx.sender) is Account
     assert tx.sender == accounts[0]
-    assert type(tx.receiver) is str
+    assert type(tx.receiver) is EthAddress
     assert tx.receiver == accounts[1].address
 
 
 def test_receiver_contract(accounts, tester):
     tx = tester.doNothing({'from': accounts[0]})
-    assert type(tx.receiver) is str
+    assert type(tx.receiver) is EthAddress
     assert tester == tx.receiver
     data = tester.revertStrings.encode_abi(5)
     tx = accounts[0].transfer(tester.address, 0, data=data)
-    assert type(tx.receiver) is str
+    assert type(tx.receiver) is EthAddress
     assert tester == tx.receiver
 
 

--- a/tests/network/transaction/test_trace.py
+++ b/tests/network/transaction/test_trace.py
@@ -7,6 +7,7 @@ import pytest
 
 from brownie.network.transaction import TransactionReceipt
 from brownie.project import build
+from brownie import ContractABI
 
 
 @pytest.fixture
@@ -174,7 +175,6 @@ def test_revert_string_from_trace(console_mode, tester):
 
 def test_inlined_library_jump(accounts, tester):
     tx = tester.useSafeMath(6, 7)
-
     assert max([i['jumpDepth'] for i in tx.trace]) == 1
 
 
@@ -191,3 +191,18 @@ def test_delegatecall_jump(accounts, librarytester):
     tx = contract.callLibrary(6, 7)
     assert max([i['depth'] for i in tx.trace]) == 1
     assert max([i['jumpDepth'] for i in tx.trace]) == 0
+
+
+def test_unknown_contract(accounts, testproject, tester):
+    ext = accounts[0].deploy(testproject.ExternalCallTester)
+    tx = tester.makeExternalCall(ext, 4)
+    del testproject.ExternalCallTester[0]
+    tx.call_trace()
+
+
+def test_contractabi(accounts, testproject, tester):
+    ext = accounts[0].deploy(testproject.ExternalCallTester)
+    tx = tester.makeExternalCall(ext, 4)
+    del testproject.ExternalCallTester[0]
+    ext = ContractABI(ext.address, "ExternalTesterABI", ext.abi)
+    tx.call_trace()

--- a/tests/network/transaction/test_trace.py
+++ b/tests/network/transaction/test_trace.py
@@ -7,7 +7,7 @@ import pytest
 
 from brownie.network.transaction import TransactionReceipt
 from brownie.project import build
-from brownie import ContractABI
+from brownie import Contract
 
 
 @pytest.fixture
@@ -204,5 +204,5 @@ def test_contractabi(accounts, testproject, tester):
     ext = accounts[0].deploy(testproject.ExternalCallTester)
     tx = tester.makeExternalCall(ext, 4)
     del testproject.ExternalCallTester[0]
-    ext = ContractABI(ext.address, "ExternalTesterABI", ext.abi)
+    ext = Contract(ext.address, "ExternalTesterABI", ext.abi)
     tx.call_trace()


### PR DESCRIPTION
* create `Contract` instances using only ABI, closes #160 
* properly handle unknown contracts when expanding transaction traces
* simplify callback on contract deployment
* update tests and docs