### PR TITLE
expand EventDict and _EventItem __getitem__

### DIFF
--- a/brownie/exceptions.py
+++ b/brownie/exceptions.py
@@ -71,6 +71,10 @@ class VirtualMachineError(Exception):
             super().__init__(exc['message'])
 
 
+class EventLookupError(LookupError):
+    pass
+
+
 # project/
 
 class ContractExists(Exception):

--- a/docs/api-brownie.rst
+++ b/docs/api-brownie.rst
@@ -304,6 +304,10 @@ network
 
     Raised when a contract call causes the EVM to revert.
 
+.. py:exception:: brownie.exceptions.EventLookupError
+
+    Raised during lookup errors by ``EventDict`` and ``_EventItem``.
+
 project
 *******
 

--- a/tests/brownie-test-project/contracts/BrownieTester.sol
+++ b/tests/brownie-test-project/contracts/BrownieTester.sol
@@ -26,6 +26,7 @@ contract BrownieTester {
 
     event TupleEvent(address addr, Base base);
     event Debug(uint a);
+    event IndexedEvent(string indexed str, uint256 indexed num);
 
     constructor (bool success) public {
         require(success);
@@ -47,6 +48,13 @@ contract BrownieTester {
     }
 
     function doNothing() external returns (bool) {
+        return true;
+    }
+
+    function emitEvents(string calldata str, uint256 num) external returns (bool) {
+        emit Debug(num);
+        emit IndexedEvent(str, num);
+        emit Debug(num + 2);
         return true;
     }
 

--- a/tests/network/test_event.py
+++ b/tests/network/test_event.py
@@ -3,37 +3,85 @@
 import pytest
 
 from brownie.network.event import EventDict, _EventItem
+from brownie.exceptions import EventLookupError
 
 
 @pytest.fixture
 def event(accounts, tester):
-    value = ["blahblah", accounts[1], ("yesyesyes", "0x1234")]
-    tx = tester.setTuple(value)
+    tx = tester.emitEvents("foo bar", 42)
     return tx.events
 
 
-def test_values(accounts, event):
-    assert event[0]['addr'] == accounts[1]
-    assert event[0]['base'] == ["blahblah", accounts[1], ("yesyesyes", "0x1234")]
+def test_tuple_values(accounts, tester):
+    value = ["blahblah", accounts[1], ("yesyesyes", "0x1234")]
+    tx = tester.setTuple(value)
+    assert tx.events[0]['addr'] == accounts[1]
+    assert tx.events[0]['base'] == value
 
 
 def test_types(event):
     assert type(event) is EventDict
     assert type(event[0]) is _EventItem
-    assert type(event['TupleEvent']) is _EventItem
+    assert type(event['Debug']) is _EventItem
+    assert type(event['IndexedEvent']) is _EventItem
 
 
 def test_count(event):
-    assert len(event) == 1
-    assert event.count('TupleEvent') == 1
+    assert len(event) == 3
+    assert event.count('IndexedEvent') == len(event['IndexedEvent']) == 1
+    assert event.count('Debug') == len(event['Debug']) == 2
 
 
-def test_equality_getitem_pos(event):
-    assert event[0] == event['TupleEvent']
+def test_equality(event):
+    assert event[1] == event['IndexedEvent']
+    assert event[0] != event['Debug']
+    assert event[0] == event['Debug'][0]
+    assert event[0] != event[-1]
+
+
+def test_pos(event):
     assert event[0].pos == (0,)
+    assert event['Debug'].pos == (0, 2)
+    assert event['IndexedEvent'].pos == (1,)
+
+
+def test_contains(event):
+    assert 'Debug' in event
+    assert 'Debug' not in event['Debug']
+    assert 'a' not in event
+    assert 'a' in event['Debug']
+
+
+def test_keys(event):
+    assert event.keys() == ['Debug', 'IndexedEvent']
+    assert event['IndexedEvent'].keys() == ['str', 'num']
 
 
 def test_str(event):
     str(event)
-    str(event[0])
-    str(event['TupleEvent'])
+    str(event['Debug'])
+    str(event['IndexedEvent'])
+
+
+def test_indexed(event):
+    assert event['IndexedEvent']['str'] == event['IndexedEvent']['str (indexed)']
+    assert str(event['IndexedEvent']['str']) != "foo bar"
+    assert event['IndexedEvent']['num'] == 42
+
+
+def test_eventdict_raises(event):
+    with pytest.raises(TypeError):
+        event[23.3]
+    with pytest.raises(EventLookupError):
+        event[4]
+    with pytest.raises(EventLookupError):
+        event['foo']
+
+
+def test_eventitem_raises(event):
+    with pytest.raises(TypeError):
+        event['Debug'][23.3]
+    with pytest.raises(EventLookupError):
+        event['Debug'][4]
+    with pytest.raises(EventLookupError):
+        event['Debug']['foo']


### PR DESCRIPTION
### What was wrong / missing?
`eth-event` appends ` (indexed)` to the indexed keys names that could not be decrypted.  This change modifies `EventDict` and `_EventItem` so that those event keys can still be queried without including indexed, and improves the exception verbosity when a key isn't found.
