### PR TITLE
add test.json info in docs

### DIFF
--- a/brownie/project/main.py
+++ b/brownie/project/main.py
@@ -25,7 +25,6 @@ FOLDERS = [
     "tests",
     "build",
     "build/contracts",
-    "build/tests"
 ]
 MIXES_URL = "https://github.com/brownie-mix/{}-mix/archive/master.zip"
 

--- a/docs/compile.rst
+++ b/docs/compile.rst
@@ -175,4 +175,4 @@ All build files include a ``coverageMap`` which is used when evaluating test cov
 * Each ``statement`` index exists on a single program counter step. The statement is considered to have executed when the corresponding opcode executes within a transaction.
 * Each ``branch`` index is found on two program counters, one of which is always a ``JUMPI`` instruction. A transaction must run both opcodes before the branch is considered to have executed. Whether it evaluates true or false depends on if the jump occurs.
 
-See :ref:`test-coverage` for more information on test coverage evaluation.
+See :ref:`tests-coverage-map-indexes` for more information.


### PR DESCRIPTION
Adds documentation about format of `build/tests.json`