### PR TITLE
Add pre-commit hooks and black formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+    -   id: check-yaml
+-   repo: https://github.com/psf/black
+    rev: 19.3b0
+    hooks:
+      - id: black
+        name: fmt
+
+default_language_version:
+    python: python3.7

--- a/README.md
+++ b/README.md
@@ -54,6 +54,25 @@ Then use ``tox`` to run the complete suite against the full set of build targets
 
 Help is always appreciated! Feel free to open an issue if you find a problem, or a pull request if you've solved an issue.
 
+### Pre-Commit Hooks
+
+We use [pre-commit](https://pre-commit.com/) hooks, primarily to ensure consistent formatting among contributors.
+
+If you haven't already, install all dev dependencies in `requirements-dev.txt` to enable pre-commit hooks.
+
+Install pre-commit locally from the brownie root folder:
+
+```bash
+pre-commit install
+```
+
+Commiting will now automatically run the local pre-commit hooks.
+
+If, for some reason, you need to force the commit without running the pre-commit hooks, you can manually disable the pre-commit.
+```bash
+git commit -m "commit message" --no-verify
+```
+
 ## License
 
 This project is licensed under the [MIT license](LICENSE).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,27 @@
+# Brownie configuration for Black.
+
+# NOTE: you have to use single-quoted strings in TOML for regular expressions.
+# It's the equivalent of r-strings in Python.  Multiline strings are treated as
+# verbose regular expressions by Black.  Use [ ] to denote a significant space
+# character.
+
+[tool.black]
+line-length = 88
+target-version = ['py36', 'py37', 'py38']
+include = '\.pyi?$'
+exclude = '''
+/(
+    \.eggs
+  | \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | _build
+  | buck-out
+  | build
+  | dist
+  | env
+  | venv
+)/
+'''

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ python =
 
 [flake8]
 max-line-length=100
-ignore=W504
+ignore=E203,W503,W504
 exclude=tests/brownie-test-project
 
 [testenv:lint]


### PR DESCRIPTION
Adds pre-commit hooks with documentation in the README as well as black formatting on the existing codebase.

Let me know what you think. Would this be helpful for the project?