### PR TITLE
Estimate gas fix

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,5 +1,5 @@
 * `brownie` Version: x.x.x
-* `py-solc-x` Verision: x.x.x
+* `ganache-cli` Version: x.x.x
 * `solc` Version: x.x.x
 * Python Version: x.x.x
 * OS: osx/linux/win

--- a/brownie/_config.py
+++ b/brownie/_config.py
@@ -102,7 +102,7 @@ def modify_network_config(network=None):
 
         if ARGV['cli'] == "test":
             CONFIG['active_network'].update(CONFIG['pytest'])
-            if not CONFIG['active_network']['broadcast_reverting_tx']:
+            if not CONFIG['active_network']['reverting_tx_gas_limit']:
                 print("WARNING: Reverting transactions will NOT be broadcasted.")
         return CONFIG['active_network']
     except KeyError:

--- a/brownie/data/config.json
+++ b/brownie/data/config.json
@@ -4,9 +4,10 @@
     "network": {
         "default": "development", // the default network that brownie connects to
         "settings": {
-            "broadcast_reverting_tx": false,
             "gas_limit": false,
-            "gas_price": false
+            "gas_price": false,
+            // if set to false, reverting tx's will raise without broadcasting
+            "reverting_tx_gas_limit": false
         },
         "networks": { // any settings given here will replace the defaults
             "development": {
@@ -19,7 +20,7 @@
                     "mnemonic": "brownie"
                 },
                 "host": "http://127.0.0.1",
-                "broadcast_reverting_tx": true
+                "reverting_tx_gas_limit": 6721975
             },
             // replace INFURA_PROJECT_ID with your personal API token
             "goerli": {
@@ -39,7 +40,7 @@
     "pytest": { // these settings replace the defaults when running pytest
         "gas_limit": 6721975,
         "default_contract_owner": false,
-        "broadcast_reverting_tx": true,
+        "reverting_tx_gas_limit": 6721975,
         "revert_traceback": false
     },
     "compiler": {

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -33,7 +33,7 @@ The following settings are available:
 
         * ``gas_price``: The default gas price for all transactions. If left as ``false`` the gas price will be determined using ``web3.eth.gasPrice``.
         * ``gas_limit``: The default gas limit for all transactions. If left as ``false`` the gas limit will be determined using ``web3.eth.estimateGas``.
-        * ``broadcast_reverting_tx``: Optional. If set to ``false``, transactions that would revert will instead raise a ``VirtualMachineError``.
+        * ``reverting_tx_gas_limit``: The gas limit to use when a transaction would revert. If set to ``false``, transactions that would revert will instead raise a ``VirtualMachineError``.
 
     .. py:attribute:: network.networks
 
@@ -76,7 +76,7 @@ The following settings are available:
 
     * ``gas_limit``: Replaces the default network gas limit.
     * ``default_contract_owner``: If ``false``, deployed contracts will not remember the account that they were created by and you will have to supply a ``from`` kwarg for every contract transaction.
-    * ``broadcast_reverting_tx``: Replaces the default network setting for broadcasting reverting transactions.
+    * ``reverting_tx_gas_limit``: Replaces the default network setting for the gas limit on a tx that will revert.
     * ``revert_traceback``: if ``true``, unhandled ``VirtualMachineError`` exceptions will include a full traceback for the reverted transaction.
 
 .. py:attribute:: colors

--- a/docs/tests.rst
+++ b/docs/tests.rst
@@ -451,7 +451,7 @@ The following test configuration settings are available in ``brownie-config.json
     {
         "test": {
             "gas_limit": 6721975,
-            "broadcast_reverting_tx": true,
+            "reverting_tx_gas_limit": 6721975,
             "default_contract_owner": false,
             "revert_traceback": false
         }
@@ -461,9 +461,9 @@ The following test configuration settings are available in ``brownie-config.json
 
     Replaces the default network gas limit.
 
-.. py:attribute:: broadcast_reverting_tx
+.. py:attribute:: reverting_tx_gas_limit
 
-    Replaces the default network setting for broadcasting transactions that would revert.
+    Replaces the default network setting for the gas limit on a tx that will revert.
 
 .. py:attribute:: default_contract_owner
 

--- a/tests/network/account/test_account_transfer.py
+++ b/tests/network/account/test_account_transfer.py
@@ -52,12 +52,12 @@ def test_returns_tx_on_revert_in_console(accounts, tester, console_mode):
 
 
 def test_broadcast_revert(accounts, tester, config):
-    config['active_network']['broadcast_reverting_tx'] = False
+    config['active_network']['reverting_tx_gas_limit'] = False
     assert accounts[1].nonce == 0
     with pytest.raises(VirtualMachineError):
         accounts[1].transfer(tester, 0)
     assert accounts[1].nonce == 0
-    config['active_network']['broadcast_reverting_tx'] = True
+    config['active_network']['reverting_tx_gas_limit'] = 1000000
     with pytest.raises(VirtualMachineError):
         accounts[1].transfer(tester, 0)
     assert accounts[1].nonce == 1


### PR DESCRIPTION
### What was wrong / missing?
Fixed https://github.com/iamdefinitelyahuman/brownie/issues/184


### How was it fixed / added?
* catch exceptions raised when gas estimation fails from a reverting tx
* change config: `broadcast_reverting_tx` -> `reverting_tx_gas_limit`

