### PR TITLE
Add non-local networks section

### DIFF
--- a/docs/nonlocal-networks.rst
+++ b/docs/nonlocal-networks.rst
@@ -125,7 +125,7 @@ Transactions
 ------------
 
 * Transaction status
-When submitting transactions on non-local networks, blocks are not immediately so transactions will likewise not be immediately confirmed. 
+When submitting transactions on non-local networks, blocks are not mined immediately so transactions will likewise not be immediately confirmed. 
 Brownie does not provide a transaction receipt by default but will wait until the transaction has been confirmed before continuing execution.  
 Press ``Ctrl-C`` and a :ref:`api-network-tx` object will be returned with the pending transaction hash and can be stored to unique variables. ``TransactionReceipt.status`` will be ``-1`` until the transaction is mined and either succeeds or reverts.  
 

--- a/docs/nonlocal-networks.rst
+++ b/docs/nonlocal-networks.rst
@@ -68,7 +68,7 @@ Using the CLI
 
 Brownie will connect to whichever network is set as "default" in ``brownie-config.json``.  
 
-To connect to any other network that has been defined in ``brownie-config.json``, you must specify the `--network` flag when launching Brownie as below:
+To connect to any other network that has been defined in ``brownie-config.json``, you must specify the ``--network`` flag when launching Brownie as below:
 ::
     $ brownie --network ropsten
 

--- a/docs/nonlocal-networks.rst
+++ b/docs/nonlocal-networks.rst
@@ -59,7 +59,6 @@ To connect to any other network that has been defined in ``brownie-config.json``
 ::
     $ brownie --network ropsten
 
-Brownie will launch or attach to the client when using any network that includes a ``test-rpc`` dictionary in it's settings.
 
 Each time Brownie is loaded, it will first attempt to connect to the ``host`` address to determine if the RPC client is already active.
 
@@ -89,7 +88,7 @@ Disconnecting from a network:
 Interacting with non-local networks
 ==============================
 
-Test-rpc
+``brownie.module.rpc``
 --------
 
 The :ref:`rpc` module is unavailable when working with non-local networks.
@@ -125,9 +124,9 @@ This means that the below ``TransactionReceipt`` attributes and methods are unav
 * ``TransactionReceipt.traceback``
 * ``TransactionReceipt.source``
 
-Contracts
+:ref:`api-network-contract`
 ---------
-On non-local networks, use the :ref:`api-network-contract` class to interact with deployed contracts.  ``ContractContainer`` and ``ProjectContract`` are unavailable as these are only used with the local   
+On non-local networks, use the ``Contract`` class to interact with deployed contracts.  ``ContractContainer`` and ``ProjectContract`` are unavailable as these are only used with the local   
 
 You can instantiate the contract using ``contract.Contract`` method.  You will need to provide an ABI (typically as a JSON file) that is generated from the compiled contract code.  
 

--- a/docs/nonlocal-networks.rst
+++ b/docs/nonlocal-networks.rst
@@ -115,10 +115,10 @@ When interacting with a non-local network via a hosted node such as Infura, you 
 
 .. code-block:: python
 
-        >>> accounts.add('8fa2fdfb89003176a16b707fc860d0881da0d1d8248af210df12d37860996fb2')
-        <Account object '0xc1826925377b4103cC92DeeCDF6F96A03142F37a'>
-        >>> accounts[0].balance()
-        17722750299000000000
+    >>> accounts.add('8fa2fdfb89003176a16b707fc860d0881da0d1d8248af210df12d37860996fb2')
+    <Account object '0xc1826925377b4103cC92DeeCDF6F96A03142F37a'>
+    >>> accounts[0].balance()
+    17722750299000000000
 
 Once an account is added to the account object, the ``accounts.save`` and ``accounts.load`` can be used to save the accounts to an encrypted keystore and then load for later use.
 
@@ -148,7 +148,7 @@ Contracts
 On non-local networks, use the ``Contract`` class to interact with already deployed contracts.  
 
 
-You can instantiate the contract using ``contract.Contract`` method.  You will need to provide an ABI (typically as a JSON file) that is generated from the compiled contract code.  
+You can instantiate the contract using ``contract.Contract`` method.  You will need to provide an ABI that is generated from the compiled contract code.  Note, this ABI must be provided as JSON interface object, not a file object or other structures.
 
 .. code-block:: python
 

--- a/docs/nonlocal-networks.rst
+++ b/docs/nonlocal-networks.rst
@@ -33,7 +33,7 @@ First, for each network you want to configure, create a new section in the netwo
         .
         .
         "ropsten": {
-            "host": "http://ropsten.infura.io/v3/[yourInfuraApiKey]"
+            "host": "http://ropsten.infura.io/v3/$WEB3_INFURA_PROJECT_ID"
         }
         "rinkeby":...
         .

--- a/docs/nonlocal-networks.rst
+++ b/docs/nonlocal-networks.rst
@@ -49,7 +49,6 @@ The environment variable is set to ``WEB3_INFURA_PROJECT_ID`` in the default con
 Setting the default nerwork
 ---------------------------
 
-Brownie''s default configuration uses the environment variable WEB3_INFURA_PROJECT_ID.
 
 If you want to change the default network that brownie connects to, you need to update the network.default field as below:
 

--- a/docs/nonlocal-networks.rst
+++ b/docs/nonlocal-networks.rst
@@ -110,7 +110,7 @@ Accounts
 
 If you are connected to your own private node, Brownie will automatically load any unlocked accounts returned by your node.  In this case, there is no need to use ``accounts.load``.
 
-When interacting with a non-local network via a hosted node like Infura, you must provide the private key when loading your acccount in order to be able to sign transactions or deploy contracts
+When interacting with a non-local network via a hosted node such as Infura, you must provide the private key when loading your account in order to be able to sign transactions or deploy contracts.
 
 .. code-block:: python
 

--- a/docs/nonlocal-networks.rst
+++ b/docs/nonlocal-networks.rst
@@ -40,7 +40,9 @@ First, for each network you want to configure, create a new section in the netwo
         .
     }
 
-You can also set your Infura API key as an environment variable from the command line as below.  
+If using Infura, you can provide your project ID key as an environment variable or by modifying the ``hosts`` setting in the configuration file.
+
+The environment variable is set to ``WEB3_INFURA_PROJECT_ID`` in the default configuration file.  Use the following command to set the environment variable:
 ::
     $ export WEB3_INFURA_PROJECT_ID=YourProjectID
 

--- a/docs/nonlocal-networks.rst
+++ b/docs/nonlocal-networks.rst
@@ -15,10 +15,13 @@ Before you go any farther, consider that connecting to non-local networks can po
 
 Register with Infura
 ========================
-Before you can connect to a non-local network, you need access to a remote Ethereum node that supports JSON RPC over HTTP.  `Infura <https://infura.io>`__ is one such option.  Once you register and create a project, Infura will provide you URLs with the API key that can be leveraged to access the given network.
+Before you can connect to a non-local network, you need access to an Ethereum node (whether your own local one or hosted) that supports JSON RPC (either HTTP, IPC, or web-sockets).  `Infura <https://infura.io>`__ is a good option for accessing a hosted node.  Once you register and create a project, Infura will provide you URLs with the API key that can be leveraged to access the given network.
 
 Non-local Network Configuration
 ================================
+
+Configuring non-local networks
+------------------------------
 
 The connection settings for non-local networks must be defined in ``brownie-config.json``.
 
@@ -36,6 +39,15 @@ First, for each network you want to configure, create a new section in the netwo
         .
         .
     }
+
+You can also set your Infura API key as an environment variable from the command line as below.  
+::
+    $ export WEB3_INFURA_PROJECT_ID=YourProjectID
+
+Setting the default nerwork
+---------------------------
+
+Brownie''s default configuration uses the environment variable WEB3_INFURA_PROJECT_ID.
 
 If you want to change the default network that brownie connects to, you need to update the network.default field as below:
 
@@ -96,7 +108,9 @@ The :ref:`rpc` module is unavailable when working with non-local networks.
 Accounts
 --------
 
-When loading an account for interacting with a non-local network, you must provide the private key when loading the account in order to be able to sign transactions or deploy contracts
+If you are connected to your own private node, Brownie will automatically load any unlocked accounts returned by your node.  In this case, there is no need to use ``accounts.load``.
+
+When interacting with a non-local network via a hosted node like Infura, you must provide the private key when loading your acccount in order to be able to sign transactions or deploy contracts
 
 .. code-block:: python
 
@@ -111,8 +125,9 @@ Transactions
 ------------
 
 * Transaction status
-When submitting a transaction on non-local networks, blocks are not immediately so transactions will likewise not be immediately confirmed. 
-A :ref:`api-network-tx` object is provided immediately and can be stored to unique variables though ``TransactionReceipt.status`` will be ``-1`` until the transaction is mined and either succeeds or reverts.  
+When submitting transactions on non-local networks, blocks are not immediately so transactions will likewise not be immediately confirmed. 
+Brownie does not provide a transaction receipt by default but will wait until the transaction has been confirmed before continuing execution.  
+Press ``Ctrl-C`` and a :ref:`api-network-tx` object will be returned with the pending transaction hash and can be stored to unique variables. ``TransactionReceipt.status`` will be ``-1`` until the transaction is mined and either succeeds or reverts.  
 
 * Debugging 
 The Brownie :ref:`debug` tools rely upon `debug_traceTransaction <https://github.com/ethereum/go-ethereum/wiki/Management-APIs#user-content-debug_tracetransaction>`__ RPC method which is not supported by `Infura <https://infura.io>`__. Attempts to call it will result in a ``RPCRequestError``.
@@ -126,7 +141,11 @@ This means that the below ``TransactionReceipt`` attributes and methods are unav
 
 :ref:`api-network-contract`
 ---------
-On non-local networks, use the ``Contract`` class to interact with deployed contracts.  ``ContractContainer`` and ``ProjectContract`` are unavailable as these are only used with the local   
+Contracts
+*********
+
+On non-local networks, use the ``Contract`` class to interact with already deployed contracts.  
+
 
 You can instantiate the contract using ``contract.Contract`` method.  You will need to provide an ABI (typically as a JSON file) that is generated from the compiled contract code.  
 
@@ -136,3 +155,7 @@ You can instantiate the contract using ``contract.Contract`` method.  You will n
     <Token Contract object '0x79447c97b6543F6eFBC91613C655977806CB18b0'>
 
 Once instantiated, any of the ``Contract``, :ref:`api-contract-call`, or :ref:`api-contract-tx` attributes and methods can be used to interact with the contract.
+
+ProjectContract
+***************
+If you use Brownie to deploy a contract to a non-local network as part of an active project, you can use the :ref:`api-network-contractcontainer`'s ``ContractContainer.at`` method to instantiate a ``ProjectContract`` instance.  Once instantiated, any of the ``Contract`` methods can be used 

--- a/docs/nonlocal-networks.rst
+++ b/docs/nonlocal-networks.rst
@@ -75,10 +75,21 @@ Connecting to a network:
                 print("Successfully connected to " + network.show_active())
             else;
                 print("Did not connect to network")
-        
+
 Disconnecting from a network:
 .. code-block:: python
     from brownie import *
-
         def main():
             network.disconnect()
+
+
+Interacting with non-local networks
+===================================
+
+Accounts
+--------
+
+More to come
+
+Contracts
+---------

--- a/docs/nonlocal-networks.rst
+++ b/docs/nonlocal-networks.rst
@@ -8,8 +8,8 @@ In addition to using `ganache-cli <https://github.com/trufflesuite/ganache-cli>`
 
 Warning
 ========================
-Before you go any farther, consider that connecting to non-local networks can potentially open you up to several risks, including the below:
-* When you are interacting with mainnet, make sure you verify all of the details of any transactions you sign/send before you send them.  
+Before you go any farther, consider that connecting to non-local networks can potentially expose your private keys if you aren't careful:
+* When you are interacting with mainnet, make sure you verify all of the details of any transactions you sign/send before you send them. Brownie can't protect you from sending ETH to the wrong address, sending too much, etc. 
 * Always protect your private keys.  Don't leave them lying around unencrypted!
 
 Register with Infura
@@ -17,9 +17,9 @@ Register with Infura
 Before you can connect to a non-local network, you need access to a remote Ethereum node that supports JSON RPC over HTTP.  `Infura <https://infura.io>`__ is one such option.  Once you register and create a project, Infura will provide you URLs with the API key that can be leveraged to access the given network.
 
 Non-local Network Configuration
-========================
+================================
 
-The connection settings for non-local networks must be defined in ``brownie-config.json``.  
+The connection settings for non-local networks must be defined in ``brownie-config.json``.
 
 First, for each network you want to configure, create a new section in the network.networks section as below:
 
@@ -36,6 +36,7 @@ First, for each network you want to configure, create a new section in the netwo
     }
 
 If you want to change the default network that brownie connects to, you need to update the network.default field as below:
+
 .. code-block:: javascript
     "network": {
         "default": "ropsten",
@@ -46,7 +47,9 @@ If you want to change the default network that brownie connects to, you need to 
 Launching and Connecting
 ========================
 
-By default, Brownie will connect to the local network run by `ganache-cli <https://github.com/trufflesuite/ganache-cli>`__.  To connect to a non-local network, you must specify the `--network` flag when launching Brownie. 
+By default, Brownie will connect to the local network run by `ganache-cli <https://github.com/trufflesuite/ganache-cli>`__.  To connect to a non-local network, you must specify the `--network` flag when launching Brownie as below:
+::
+    $ brownie --network ropsten
 
 Brownie will launch or attach to the client when using any network that includes a ``test-rpc`` dictionary in it's settings.
 

--- a/docs/nonlocal-networks.rst
+++ b/docs/nonlocal-networks.rst
@@ -8,7 +8,8 @@ In addition to using `ganache-cli <https://github.com/trufflesuite/ganache-cli>`
 
 Warning
 ========================
-Before you go any farther, consider that connecting to non-local networks can potentially expose your private keys if you aren't careful:
+Before you go any farther, consider that connecting to non-local networks can potentially expose your private keys if you aren't careful.
+
 * When you are interacting with mainnet, make sure you verify all of the details of any transactions you sign/send before you send them. Brownie can't protect you from sending ETH to the wrong address, sending too much, etc. 
 * Always protect your private keys.  Don't leave them lying around unencrypted!
 
@@ -68,6 +69,7 @@ Using the ``brownie.netowrk`` methods
 You can interact with any network defined in ``brownie-config.json`` programatically using the ``brownie.network.main`` methods.
 
 Connecting to a network:
+
 .. code-block:: python
 
     >>> network.connect('ropsten')    
@@ -77,19 +79,24 @@ Connecting to a network:
     'ropsten'
 
 Disconnecting from a network:
+
 .. code-block:: python
 
     >>> network.disconnect()
     >>> network.is_connected()
     False
 
-Interacting with  non-local networks
+Interacting with non-local networks
 ==============================
+
+Test-rpc
+--------
+
+The :ref:`rpc` module is unavailable when working with non-local networks.
 
 Accounts
 --------
 
-* Configuring accounts for use with non-local networks
 When loading an account for interacting with a non-local network, you must provide the private key when loading the account in order to be able to sign transactions or deploy contracts
 
 .. code-block:: python
@@ -101,8 +108,32 @@ When loading an account for interacting with a non-local network, you must provi
 
 Once an account is added to the account object, the ``accounts.save`` and ``accounts.load`` can be used to save the accounts to an encrypted keystore and then load for later use.
 
-* Unconfirmed transactions
-On non-local networks, blocks are not mined automatically so transaction confirmations will not be immediate.  Transaction receipts are provided immediately can be stored to unique variables.  Individual transaction objects can also be accessed using the ``history`` function.  
+Transactions
+------------
+
+* Transaction status
+When submitting a transaction on non-local networks, blocks are not immediately so transactions will likewise not be immediately confirmed. 
+A :ref:`api-network-tx` object is provided immediately and can be stored to unique variables though ``TransactionReceipt.status`` will be ``-1`` until the transaction is mined and either succeeds or reverts.  
+
+* Debugging 
+The Brownie :ref:`debug` tools rely upon `debug_traceTransaction <https://github.com/ethereum/go-ethereum/wiki/Management-APIs#user-content-debug_tracetransaction>`__ RPC method which is not supported by `Infura <https://infura.io>`__. Attempts to call it will result in a ``RPCRequestError``.
+This means that the below ``TransactionReceipt`` attributes and methods are unavailable:
+
+* ``TransactionReceipt.return_value``
+* ``TransactionReceipt.trace``
+* ``TransactionReceipt.call_trace``
+* ``TransactionReceipt.traceback``
+* ``TransactionReceipt.source``
 
 Contracts
 ---------
+On non-local networks, use the :ref:`api-network-contract` class to interact with deployed contracts.  ``ContractContainer`` and ``ProjectContract`` are unavailable as these are only used with the local   
+
+You can instantiate the contract using ``contract.Contract`` method.  You will need to provide an ABI (typically as a JSON file) that is generated from the compiled contract code.  
+
+.. code-block:: python
+
+    >>> Contract('0x79447c97b6543F6eFBC91613C655977806CB18b0', "Token", abi)
+    <Token Contract object '0x79447c97b6543F6eFBC91613C655977806CB18b0'>
+
+Once instantiated, any of the ``Contract``, :ref:`api-contract-call`, or :ref:`api-contract-tx` attributes and methods can be used to interact with the contract.

--- a/docs/nonlocal-networks.rst
+++ b/docs/nonlocal-networks.rst
@@ -44,8 +44,11 @@ If you want to change the default network that brownie connects to, you need to 
         .
     }
 
-Launching and Connecting
-========================
+Launching and Connecting to Networks
+====================================
+
+Using the CLI
+-------------
 
 Brownie will connect to whichever network is set as "default" in ``brownie-config.json``.  
 
@@ -57,4 +60,25 @@ Brownie will launch or attach to the client when using any network that includes
 
 Each time Brownie is loaded, it will first attempt to connect to the ``host`` address to determine if the RPC client is already active.
 
+Using the ``brownie.netowrk`` methods
+-------------------------------------
 
+You can interact with any network defined in ``brownie-config.json`` programatically using the ``brownie.network.main`` methods.
+
+Connecting to a network:
+.. code-block:: python
+    from brownie import *
+
+        def main():
+            network.connect(network='ropsten',launch_rpc='false')
+            if network.is_connected():
+                print("Successfully connected to " + network.show_active())
+            else;
+                print("Did not connect to network")
+        
+Disconnecting from a network:
+.. code-block:: python
+    from brownie import *
+
+        def main():
+            network.disconnect()

--- a/docs/nonlocal-networks.rst
+++ b/docs/nonlocal-networks.rst
@@ -70,29 +70,39 @@ You can interact with any network defined in ``brownie-config.json`` programatic
 Connecting to a network:
 .. code-block:: python
 
-    from brownie import *
-
-        def main():
-            network.connect(network='ropsten',launch_rpc='false')
-            if network.is_connected():
-                print("Successfully connected to " + network.show_active())
-            else;
-                print("Did not connect to network")
+    >>> network.connect('ropsten')    
+    >>> network.is_connected()
+    True
+    >>> network.show_active()
+    'ropsten'
 
 Disconnecting from a network:
 .. code-block:: python
-    from brownie import *
-        def main():
-            network.disconnect()
 
+    >>> network.disconnect()
+    >>> network.is_connected()
+    False
 
-Interacting with non-local networks
-===================================
+Interacting with  non-local networks
+==============================
 
 Accounts
 --------
 
-More to come
+* Configuring accounts for use with non-local networks
+When loading an account for interacting with a non-local network, you must provide the private key when loading the account in order to be able to sign transactions or deploy contracts
+
+.. code-block:: python
+
+        >>> accounts.add('8fa2fdfb89003176a16b707fc860d0881da0d1d8248af210df12d37860996fb2')
+        <Account object '0xc1826925377b4103cC92DeeCDF6F96A03142F37a'>
+        >>> accounts[0].balance()
+        17722750299000000000
+
+Once an account is added to the account object, the ``accounts.save`` and ``accounts.load`` can be used to save the accounts to an encrypted keystore and then load for later use.
+
+* Unconfirmed transactions
+On non-local networks, blocks are not mined automatically so transaction confirmations will not be immediate.  Transaction receipts are provided immediately can be stored to unique variables.  Individual transaction objects can also be accessed using the ``history`` function.  
 
 Contracts
 ---------

--- a/docs/nonlocal-networks.rst
+++ b/docs/nonlocal-networks.rst
@@ -9,27 +9,38 @@ In addition to using `ganache-cli <https://github.com/trufflesuite/ganache-cli>`
 Warning
 ========================
 Before you go any farther, consider that connecting to non-local networks can potentially open you up to several risks, including the below:
-* Brownie is a testing framework and not designed for interactions with any mainnet (Ethereum, xDai, POA, etc.) and has not been audited for any security risks
-* Brownie should not be used to sign or send transactions to any mainnet or real value can potentially be lost.
-* If you use an account where you have real value stored on any mainnet, you should not use that account when interacting with Brownie
+* When you are interacting with mainnet, make sure you verify all of the details of any transactions you sign/send before you send them.  
+* Always protect your private keys.  Don't leave them lying around unencrypted!
+
+Register with Infura
+========================
+Before you can connect to a non-local network, you need access to a remote Ethereum node that supports JSON RPC over HTTP.  `Infura <https://infura.io>`__ is one such option.  Once you register and create a project, Infura will provide you URLs with the API key that can be leveraged to access the given network.
 
 Non-local Network Configuration
 ========================
 
-The connection settings for non-local networks must be defined in ``brownie-config.json``:
+The connection settings for non-local networks must be defined in ``brownie-config.json``.  
+
+First, for each network you want to configure, create a new section in the network.networks section as below:
 
 .. code-block:: javascript
+    "networks": {
+        .
+        .
+        "ropsten": {
+            "host": "http://ropsten.infura.io/v3/[yourInfuraApiKey]"
+        }
+        "rinkeby":...
+        .
+        .
+    }
 
-    "development": {
-        "test-rpc": {
-            "cmd": "ganache-cli", // command to load the client - you can add any extra flags here as needed
-            "port": 8545,  // port the client should listen on
-            "gas_limit": 6721975,  // block gas limit
-            "accounts": 10,  // number of accounts in web3.eth.accounts
-            "evm_version": "petersburg",  // evm version
-            "mnemonic": "brownie"  // accounts are derived from this mnemonic - set to null for different addresses on each load
-        },
-        "host": "http://ropsten.infura.io/v3/[yourInfuraApiKey]"
+If you want to change the default network that brownie connects to, you need to update the network.default field as below:
+.. code-block:: javascript
+    "network": {
+        "default": "ropsten",
+        .
+        .
     }
 
 Launching and Connecting

--- a/docs/nonlocal-networks.rst
+++ b/docs/nonlocal-networks.rst
@@ -47,7 +47,9 @@ If you want to change the default network that brownie connects to, you need to 
 Launching and Connecting
 ========================
 
-By default, Brownie will connect to the local network run by `ganache-cli <https://github.com/trufflesuite/ganache-cli>`__.  To connect to a non-local network, you must specify the `--network` flag when launching Brownie as below:
+Brownie will connect to whichever network is set as "default" in ``brownie-config.json``.  
+
+To connect to any other network that has been defined in ``brownie-config.json``, you must specify the `--network` flag when launching Brownie as below:
 ::
     $ brownie --network ropsten
 
@@ -55,39 +57,4 @@ Brownie will launch or attach to the client when using any network that includes
 
 Each time Brownie is loaded, it will first attempt to connect to the ``host`` address to determine if the RPC client is already active.
 
-Client is Active
-----------------
 
-If able to connect to the ``host`` address, Brownie:
-
-* Checks the current block height and raises an Exception if it is greater than zero
-* Locates the process listening at the address and attaches it to the ``Rpc`` object
-* Takes a snapshot
-
-When Brownie is terminated:
-
-* The RPC client is reverted based on the initial snapshot.
-
-Client is not Active
---------------------
-
-If unable to connect to the ``host`` address, Brownie:
-
-* Launches the client using the ``test-rpc`` command given in the configuration file
-* Waits to see that the process loads successfully
-* Confirms that it can connect to the new process
-* Attaches the process to the ``Rpc`` object
-
-When Brownie is terminated:
-
-* The RPC client and any child processes are also terminated.
-
-Common Interactions
-===================
-
-You can interact with the RPC client using the :ref:`rpc` object, which is automatically instantiated as ``rpc``:
-
-.. code-block:: python
-
-    >>> rpc
-    <brownie.network.rpc.Rpc object at 0x7f720f65fd68>

--- a/docs/nonlocal-networks.rst
+++ b/docs/nonlocal-networks.rst
@@ -1,0 +1,79 @@
+.. _nonlocal-networks:
+
+====================
+Non-local Networks
+====================
+
+In addition to using `ganache-cli <https://github.com/trufflesuite/ganache-cli>`__ as a local development environment, Brownie can also connect to non-local networks (i.e. any testnet/mainnet node that supports JSON RPC).
+
+Warning
+========================
+Before you go any farther, consider that connecting to non-local networks can potentially open you up to several risks, including the below:
+* Brownie is a testing framework and not designed for interactions with any mainnet (Ethereum, xDai, POA, etc.) and has not been audited for any security risks
+* Brownie should not be used to sign or send transactions to any mainnet or real value can potentially be lost.
+* If you use an account where you have real value stored on any mainnet, you should not use that account when interacting with Brownie
+
+Non-local Network Configuration
+========================
+
+The connection settings for non-local networks must be defined in ``brownie-config.json``:
+
+.. code-block:: javascript
+
+    "development": {
+        "test-rpc": {
+            "cmd": "ganache-cli", // command to load the client - you can add any extra flags here as needed
+            "port": 8545,  // port the client should listen on
+            "gas_limit": 6721975,  // block gas limit
+            "accounts": 10,  // number of accounts in web3.eth.accounts
+            "evm_version": "petersburg",  // evm version
+            "mnemonic": "brownie"  // accounts are derived from this mnemonic - set to null for different addresses on each load
+        },
+        "host": "http://ropsten.infura.io/v3/[yourInfuraApiKey]"
+    }
+
+Launching and Connecting
+========================
+
+By default, Brownie will connect to the local network run by `ganache-cli <https://github.com/trufflesuite/ganache-cli>`__.  To connect to a non-local network, you must specify the `--network` flag when launching Brownie. 
+
+Brownie will launch or attach to the client when using any network that includes a ``test-rpc`` dictionary in it's settings.
+
+Each time Brownie is loaded, it will first attempt to connect to the ``host`` address to determine if the RPC client is already active.
+
+Client is Active
+----------------
+
+If able to connect to the ``host`` address, Brownie:
+
+* Checks the current block height and raises an Exception if it is greater than zero
+* Locates the process listening at the address and attaches it to the ``Rpc`` object
+* Takes a snapshot
+
+When Brownie is terminated:
+
+* The RPC client is reverted based on the initial snapshot.
+
+Client is not Active
+--------------------
+
+If unable to connect to the ``host`` address, Brownie:
+
+* Launches the client using the ``test-rpc`` command given in the configuration file
+* Waits to see that the process loads successfully
+* Confirms that it can connect to the new process
+* Attaches the process to the ``Rpc`` object
+
+When Brownie is terminated:
+
+* The RPC client and any child processes are also terminated.
+
+Common Interactions
+===================
+
+You can interact with the RPC client using the :ref:`rpc` object, which is automatically instantiated as ``rpc``:
+
+.. code-block:: python
+
+    >>> rpc
+    <brownie.network.rpc.Rpc object at 0x7f720f65fd68>

--- a/docs/nonlocal-networks.rst
+++ b/docs/nonlocal-networks.rst
@@ -24,6 +24,7 @@ The connection settings for non-local networks must be defined in ``brownie-conf
 First, for each network you want to configure, create a new section in the network.networks section as below:
 
 .. code-block:: javascript
+
     "networks": {
         .
         .
@@ -38,6 +39,7 @@ First, for each network you want to configure, create a new section in the netwo
 If you want to change the default network that brownie connects to, you need to update the network.default field as below:
 
 .. code-block:: javascript
+
     "network": {
         "default": "ropsten",
         .
@@ -67,6 +69,7 @@ You can interact with any network defined in ``brownie-config.json`` programatic
 
 Connecting to a network:
 .. code-block:: python
+
     from brownie import *
 
         def main():

--- a/docs/toctree.rst
+++ b/docs/toctree.rst
@@ -16,6 +16,7 @@ Brownie
     gui.rst
     deploy.rst
     test-rpc.rst
+    nonlocal-networks.rst
     config.rst
     python-package.rst
     api.rst


### PR DESCRIPTION
### What was wrong / missing?
Connecting to and interacting with non-local networks is not clearly documented - referenced in issue #174 


### How was it fixed / added?
Fixes #174 by adding new section to documentation that explains how to leverage Brownie to interact with non-local Ethereum networks.

