### PR TITLE
Dumping private keys when loading ganache-cli on specificied filename.

### DIFF
--- a/brownie/network/rpc.py
+++ b/brownie/network/rpc.py
@@ -22,6 +22,7 @@ CLI_FLAGS = {
     "accounts": "--accounts",
     "evm_version": "--hardfork",
     "mnemonic": "--mnemonic",
+    "acctKeys": "--acctKeys",
 }
 
 EVM_VERSIONS = ["byzantium", "constantinople", "petersburg"]

--- a/docs/test-rpc.rst
+++ b/docs/test-rpc.rst
@@ -23,6 +23,7 @@ The connection settings for the local RPC are outlined in ``brownie-config.yaml`
             accounts: 10
             evm_version: petersburg
             mnemonic: brownie
+            acctKeys: ganache-accounts.json
 
 Brownie will launch or attach to the client when using any network that includes a ``test-rpc`` dictionary in it's settings.
 


### PR DESCRIPTION
### What was wrong / missing?

Filename parameters to dump private keys on running ganache-cli. Can be useful when connecting to Ganache from an external Dapp.

### How was it fixed / added?

Added in rpc.py


