### PR TITLE
Console color fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/iamdefinitelyahuman/brownie)
 ### Fixed
 - use `isinstance` instead of `type` for conversions, fixes hexstring comparison bug
+- pretty printing for more objects in the console
+- properly display `SyntaxError` in console when there is no source highlight
 
 ## [1.1.0](https://github.com/iamdefinitelyahuman/brownie/tree/v1.1.0) - 2019-11-04
 ### Added

--- a/brownie/_cli/console.py
+++ b/brownie/_cli/console.py
@@ -53,9 +53,6 @@ class Console(code.InteractiveConsole):
         locals_dict = dict((i, getattr(brownie, i)) for i in brownie.__all__)
         locals_dict["dir"] = self._dir
 
-        self._stdout_write = sys.stdout.write
-        sys.stdout.write = self._console_write
-
         if project:
             project._update_and_register(locals_dict)
             history_file = project._project_path
@@ -81,19 +78,19 @@ class Console(code.InteractiveConsole):
         results = sorted(results, key=lambda k: k[0])
         self.write(f"[{f'{color}, '.join(_dir_color(i[1]) + i[0] for i in results)}{color}]\n")
 
-    def _console_write(self, text):
+    def _console_write(self, obj):
+        text = repr(obj)
         try:
-            obj = eval(text)
             if obj and isinstance(obj, dict):
                 text = color.pretty_dict(obj)
             elif obj and isinstance(obj, (tuple, list, set)):
                 text = color.pretty_sequence(obj)
         except (SyntaxError, NameError):
             pass
-        return self._stdout_write(text)
+        print(text)
 
     def showsyntaxerror(self, filename):
-        tb = color.format_syntaxerror(sys.exc_info()[1])
+        tb = color.format_tb(sys.exc_info()[1])
         self.write(tb + "\n")
 
     def showtraceback(self):
@@ -112,6 +109,27 @@ class Console(code.InteractiveConsole):
         except (ValueError, AttributeError, KeyError):
             pass
         return super().push(line)
+
+    def runsource(self, source, filename="<input>", symbol="single"):
+        try:
+            code = self.compile(source, filename, "single")
+        except (OverflowError, SyntaxError, ValueError):
+            self.showsyntaxerror(filename)
+            return False
+
+        if code is None:
+            return True
+
+        try:
+            self.compile(source, filename, "eval")
+            code = self.compile(f"__ret_value__ = {source}", filename, "exec")
+        except Exception:
+            pass
+        self.runcode(code)
+        if "__ret_value__" in self.locals and self.locals["__ret_value__"]:
+            self._console_write(self.locals["__ret_value__"])
+            del self.locals["__ret_value__"]
+        return False
 
 
 def _dir_color(obj):

--- a/brownie/utils/color.py
+++ b/brownie/utils/color.py
@@ -117,7 +117,7 @@ class Color:
         start: Optional[int] = None,
         stop: Optional[int] = None,
     ) -> str:
-        if isinstance(exc, SyntaxError):
+        if isinstance(exc, SyntaxError) and exc.text is not None:
             return self.format_syntaxerror(exc)
         tb = [i.replace("./", "") for i in traceback.format_tb(exc.__traceback__)]
         if filename and not ARGV["tb"]:


### PR DESCRIPTION
### What was wrong / missing?
Pretty printing of some dicts and sequences has been broken in the console since migrating to `InteractiveConsole`.


### How was it fixed / added?
- pretty printing for more objects in the console
- properly display `SyntaxError` in console when there is no source highlight

