### PR TITLE
Update Development Status to production/stable in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     include_package_data=True,
     python_requires=">=3.6,<4",
     classifiers=[
-        "Development Status :: 3 - Alpha",
+        "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
         "Topic :: Software Development :: Build Tools",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
### What was wrong / missing?

The development status classifier in setup.py seems to be out of date and does not reflect the fact that brownie is now out of beta.


### How was it fixed / added?

I changed the development status to "Development Status :: 5 - Production/Stable" in setup.py.
