### PR TITLE
remove tkinter dependency when not loading GUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - cache available solc compiler versions to avoid repeated calls
 - store data files in `~/.brownie/`
 
+### Fixed
+- removed Tkinter dependency when not loading the GUI
+
 ## [1.2.0](https://github.com/iamdefinitelyahuman/brownie/tree/v1.2.0) - 2019-11-23
 ### Added
 - [ethPM](https://docs.ethpm.com/) integration

--- a/brownie/__init__.py
+++ b/brownie/__init__.py
@@ -1,12 +1,11 @@
 #!/usr/bin/python3
 
-from brownie._config import CONFIG as config
-from brownie._gui import Gui
-from brownie.convert import Wei
-from brownie.network.contract import Contract  # NOQA: F401
 
-from .network import accounts, alert, history, rpc, web3
-from .project import compile_source, run
+from brownie._config import CONFIG as config
+from brownie.convert import Wei
+from brownie.network import accounts, alert, history, rpc, web3
+from brownie.network.contract import Contract  # NOQA: F401
+from brownie.project import compile_source, run
 
 __all__ = [
     "accounts",  # accounts is an Accounts singleton
@@ -20,5 +19,4 @@ __all__ = [
     "run",
     "Wei",
     "config",
-    "Gui",
 ]

--- a/brownie/__init__.py
+++ b/brownie/__init__.py
@@ -1,11 +1,10 @@
 #!/usr/bin/python3
 
-
 from brownie._config import CONFIG as config
 from brownie.convert import Wei
+from brownie.project import compile_source, run
 from brownie.network import accounts, alert, history, rpc, web3
 from brownie.network.contract import Contract  # NOQA: F401
-from brownie.project import compile_source, run
 
 __all__ = [
     "accounts",  # accounts is an Accounts singleton

--- a/brownie/_cli/analyze.py
+++ b/brownie/_cli/analyze.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 
+import importlib
 import json
 import re
 import time
@@ -13,7 +14,6 @@ from pythx.middleware.toolname import ClientToolNameMiddleware
 from brownie import project
 from brownie._cli.__main__ import __version__
 from brownie._config import ARGV, _update_argv_from_docopt
-from brownie._gui import Gui
 from brownie.exceptions import ProjectNotFound
 from brownie.utils import color, notify
 
@@ -301,4 +301,5 @@ def main():
     # Launch GUI if user requested it
     if ARGV["gui"]:
         print("Launching the Brownie GUI")
+        Gui = importlib.import_module("brownie._gui").Gui
         Gui().mainloop()

--- a/brownie/_cli/console.py
+++ b/brownie/_cli/console.py
@@ -2,6 +2,7 @@
 
 import atexit
 import code
+import importlib
 import sys
 
 from docopt import docopt
@@ -17,7 +18,6 @@ if sys.platform == "win32":
     readline = Readline()
 else:
     import readline  # noqa: F401
-
 
 __doc__ = f"""Usage: brownie console [options]
 
@@ -52,6 +52,13 @@ class Console(code.InteractiveConsole):
     def __init__(self, project=None):
         locals_dict = dict((i, getattr(brownie, i)) for i in brownie.__all__)
         locals_dict["dir"] = self._dir
+
+        # only make GUI available if Tkinter is installed
+        try:
+            Gui = importlib.import_module("brownie._gui").Gui
+            locals_dict["Gui"] = Gui
+        except ModuleNotFoundError:
+            pass
 
         if project:
             project._update_and_register(locals_dict)

--- a/brownie/network/__init__.py
+++ b/brownie/network/__init__.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python3
 
-from brownie import project  # NOQA F401
 
 from .account import Accounts
 from .main import connect, disconnect, gas_limit, gas_price, is_connected, show_active  # NOQA 401

--- a/brownie/network/__init__.py
+++ b/brownie/network/__init__.py
@@ -1,5 +1,7 @@
 #!/usr/bin/python3
 
+from brownie import project  # NOQA F401
+
 from .account import Accounts
 from .main import connect, disconnect, gas_limit, gas_price, is_connected, show_active  # NOQA 401
 from .rpc import Rpc

--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -17,7 +17,7 @@ from brownie.exceptions import (
     UndeployedLibrary,
     VirtualMachineError,
 )
-from brownie.project.ethpm import get_deployment_addresses, get_manifest
+from brownie.project import ethpm
 from brownie.typing import AccountsType, TransactionReceiptType
 from brownie.utils import color
 
@@ -276,10 +276,10 @@ class Contract(_DeployedContractBase):
         if manifest_uri and abi:
             raise ValueError("Contract requires either abi or manifest_uri, but not both")
         if manifest_uri is not None:
-            manifest = get_manifest(manifest_uri)
+            manifest = ethpm.get_manifest(manifest_uri)
             abi = manifest["contract_types"][name]["abi"]
             if address is None:
-                address_list = get_deployment_addresses(manifest, name)
+                address_list = ethpm.get_deployment_addresses(manifest, name)
                 if not address_list:
                     raise ContractNotFound(
                         f"'{manifest['package_name']}' manifest does not contain"

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ extras=linter
 commands =
     black --check {toxinidir}/brownie {toxinidir}/tests
     flake8 {toxinidir}/brownie {toxinidir}/tests
-    isort --check-only --diff --recursive {toxinidir}/brownie {toxinidir}/tests
+    isort --check-only --diff --recursive {toxinidir}/brownie {toxinidir}/tests --skip brownie/__init__.py
     mypy --disallow-untyped-defs {toxinidir}/brownie/project {toxinidir}/brownie/network
     mypy --allow-untyped-defs {toxinidir}/brownie
 


### PR DESCRIPTION
### What was wrong / missing?
Tkinter is an unnanounced but required dependency.

### How was it fixed / added?
Adjusted imports and use `importlib` to avoid importing `brownie._gui` except when the user explicitely requests to load the Gui.

Fixes #247 
