### PR TITLE
revert verbosity improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This changelog format is based on [Keep a Changelog](https://keepachangelog.com/
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/iamdefinitelyahuman/brownie)
+### Added
+- allow `dev:` revert comments for `assert` statements
+- better error messages when sending ether to nonpayable function, or trying to access an invalid array index
+
 ### Fixed
 - GUI properly highlights `JUMPDEST` targets within first 256 bytes
 

--- a/brownie/exceptions.py
+++ b/brownie/exceptions.py
@@ -61,22 +61,17 @@ class VirtualMachineError(Exception):
         revert_msg: The returned error string, if any.
         source: The contract source code where the revert occured, if available."""
 
-    revert_msg = ""
-    source = ""
-
     def __init__(self, exc: Any) -> None:
         if type(exc) is not dict:
             try:
                 exc = eval(str(exc))
             except SyntaxError:
                 exc = {"message": str(exc)}
-        if len(exc["message"].split("revert ", maxsplit=1)) > 1:
-            self.revert_msg = exc["message"].split("revert ")[-1]
-        if "source" in exc:
-            self.source = exc["source"]
-            super().__init__(exc["message"] + "\n" + exc["source"])
-        else:
-            super().__init__(exc["message"])
+        self.revert_msg = msg = exc["message"]
+        self.source = exc.get("source", "")
+        if self.source:
+            msg = f"{msg}\n{self.source}"
+        super().__init__(msg)
 
 
 class EventLookupError(LookupError):

--- a/brownie/network/account.py
+++ b/brownie/network/account.py
@@ -387,9 +387,11 @@ def _raise_or_return_tx(exc: ValueError) -> Any:
         data = eval(str(exc))["data"]
         txid = next(i for i in data.keys() if i[:2] == "0x")
         reason = data[txid]["reason"] if "reason" in data[txid] else None
-        pc = data[txid]["program_counter"] - 1
-        error = data[txid]["error"]
-        return txid, [reason, pc, error]
+        pc = data[txid]["program_counter"]
+        revert_type = data[txid]["error"]
+        if revert_type == "revert":
+            pc -= 1
+        return txid, [reason, pc, revert_type]
     except SyntaxError:
         raise exc
     except Exception:

--- a/brownie/network/transaction.py
+++ b/brownie/network/transaction.py
@@ -150,6 +150,8 @@ class TransactionReceipt:
             revert_msg = build._get_dev_revert(self._revert_pc)
             if isinstance(revert_msg, str):
                 self._revert_msg = revert_msg
+        else:
+            self._revert_msg = revert_type
 
         # threaded to allow impatient users to ctrl-c to stop waiting in the console
         confirm_thread = threading.Thread(
@@ -164,12 +166,12 @@ class TransactionReceipt:
             if ARGV["coverage"] and not coverage._check_cached(self.coverage_hash) and self.trace:
                 self._expand_trace()
             if not self.status:
-                if revert_msg is None:
+                if self._revert_msg is None:
                     # no revert message and unable to check dev string - have to get trace
                     self._expand_trace()
                 # raise from a new function to reduce pytest traceback length
                 _raise(
-                    f"{revert_type} {self.revert_msg or ''}",
+                    self._revert_msg or "",
                     self._traceback_string() if ARGV["revert"] else self._error_string(1),
                 )
         except KeyboardInterrupt:

--- a/brownie/network/transaction.py
+++ b/brownie/network/transaction.py
@@ -145,12 +145,12 @@ class TransactionReceipt:
         if revert_msg:
             # revert message was returned
             self._revert_msg = revert_msg
-        elif revert_type == "revert":
+        elif revert_type in ("revert", "invalid opcode"):
             # check for dev revert string as a comment
             revert_msg = build._get_dev_revert(self._revert_pc)
             if isinstance(revert_msg, str):
                 self._revert_msg = revert_msg
-        else:
+        if self._revert_msg is None and revert_type != "revert":
             self._revert_msg = revert_type
 
         # threaded to allow impatient users to ctrl-c to stop waiting in the console

--- a/brownie/network/transaction.py
+++ b/brownie/network/transaction.py
@@ -147,10 +147,8 @@ class TransactionReceipt:
             self._revert_msg = revert_msg
         elif revert_type in ("revert", "invalid opcode"):
             # check for dev revert string as a comment
-            revert_msg = build._get_dev_revert(self._revert_pc)
-            if isinstance(revert_msg, str):
-                self._revert_msg = revert_msg
-        if self._revert_msg is None and revert_type != "revert":
+            self._revert_msg = build._get_dev_revert(self._revert_pc)
+        else:
             self._revert_msg = revert_type
 
         # threaded to allow impatient users to ctrl-c to stop waiting in the console
@@ -378,7 +376,7 @@ class TransactionReceipt:
                     step = trace[i]
             self._revert_msg = pc_map[step["pc"]]["dev"]
         except KeyError:
-            self._revert_msg = ""
+            self._revert_msg = "invalid opcode" if step["op"] == "INVALID" else ""
 
     def _expand_trace(self) -> None:
         """Adds the following attributes to each step of the stack trace:

--- a/brownie/project/build.py
+++ b/brownie/project/build.py
@@ -57,7 +57,6 @@ class Build:
                 if "fn" not in data or "first_revert" in data:
                     _revert_map[pc] = False
                     continue
-                data["dev"] = ""
                 try:
                     revert_str = self._sources.get(data["path"])[data["offset"][1] :]
                     revert_str = revert_str[: revert_str.index("\n")]
@@ -66,7 +65,15 @@ class Build:
                         data["dev"] = revert_str
                 except (KeyError, ValueError):
                     pass
-            revert = (data["path"], tuple(data["offset"]), data["fn"], data["dev"], self._sources)
+
+            msg = "" if data["op"] == "REVERT" else "invalid opcode"
+            revert = (
+                data["path"],
+                tuple(data["offset"]),
+                data["fn"],
+                data.get("dev", msg),
+                self._sources,
+            )
 
             # do not compare the final tuple item in case the same project was loaded twice
             if pc not in _revert_map or (_revert_map[pc] and revert[:-1] == _revert_map[pc][:-1]):

--- a/brownie/project/build.py
+++ b/brownie/project/build.py
@@ -53,18 +53,19 @@ class Build:
             for k, v in pcMap.items()
             if v["op"] in {"REVERT", "INVALID"} or "jump_revert" in v
         ):
-            if "fn" not in data or "first_revert" in data:
-                _revert_map[pc] = False
-                continue
-            data["dev"] = ""
-            try:
-                revert_str = self._sources.get(data["path"])[data["offset"][1] :]
-                revert_str = revert_str[: revert_str.index("\n")]
-                revert_str = revert_str[revert_str.index("//") + 2 :].strip()
-                if revert_str.startswith("dev:"):
-                    data["dev"] = revert_str
-            except (KeyError, ValueError):
-                pass
+            if "dev" not in data:
+                if "fn" not in data or "first_revert" in data:
+                    _revert_map[pc] = False
+                    continue
+                data["dev"] = ""
+                try:
+                    revert_str = self._sources.get(data["path"])[data["offset"][1] :]
+                    revert_str = revert_str[: revert_str.index("\n")]
+                    revert_str = revert_str[revert_str.index("//") + 2 :].strip()
+                    if revert_str.startswith("dev:"):
+                        data["dev"] = revert_str
+                except (KeyError, ValueError):
+                    pass
             revert = (data["path"], tuple(data["offset"]), data["fn"], data["dev"], self._sources)
 
             # do not compare the final tuple item in case the same project was loaded twice

--- a/brownie/project/compiler.py
+++ b/brownie/project/compiler.py
@@ -483,6 +483,12 @@ def _generate_coverage_data(
         offset = (source[0], source[0] + source[1])
         pc_list[-1]["offset"] = offset
 
+        # add error messages for INVALID opcodes
+        if pc_list[-1]["op"] == "INVALID":
+            node = source_nodes[source[2]].children(include_children=False, offset_limits=offset)[0]
+            if node.nodeType == "IndexAccess":
+                pc_list[-1]["dev"] = "Index out of range"
+
         # if op is jumpi, set active branch markers
         if branch_active[path] and pc_list[-1]["op"] == "JUMPI":
             for offset in branch_active[path]:

--- a/brownie/project/compiler.py
+++ b/brownie/project/compiler.py
@@ -468,7 +468,7 @@ def _generate_coverage_data(
                 pc_list[-1].update(
                     {
                         "dev": "Cannot send ether to nonpayable function",
-                        "fn": pc_list[-8]["fn"],
+                        "fn": pc_list[-8].get("fn", "<unknown>"),
                         "offset": pc_list[-8]["offset"],
                         "path": pc_list[-8]["path"],
                     }

--- a/brownie/project/compiler.py
+++ b/brownie/project/compiler.py
@@ -464,6 +464,15 @@ def _generate_coverage_data(
 
         # set contract path (-1 means none)
         if source[2] == -1:
+            if pc_list[-1]["op"] == "REVERT" and pc_list[-8]["op"] == "CALLVALUE":
+                pc_list[-1].update(
+                    {
+                        "dev": "Cannot send ether to nonpayable function",
+                        "fn": pc_list[-8]["fn"],
+                        "offset": pc_list[-8]["offset"],
+                        "path": pc_list[-8]["path"],
+                    }
+                )
             continue
         path = source_nodes[source[2]].absolutePath
         pc_list[-1]["path"] = path

--- a/tests/data/brownie-test-project/contracts/EVMTester.sol
+++ b/tests/data/brownie-test-project/contracts/EVMTester.sol
@@ -115,4 +115,12 @@ contract EVMTester {
         revert(); // dev: great job
     }
 
+    uint256[3] x;
+
+    function invalidOpcodes(uint a, uint b) external returns (uint c) {
+        assert (a > 0);
+        assert (c+b > 2); // dev: foobar
+        c = x[a];
+    }
+
 }

--- a/tests/network/transaction/test_attributes.py
+++ b/tests/network/transaction/test_attributes.py
@@ -78,24 +78,6 @@ def test_modified_state(accounts, tester, console_mode):
     assert not tx.modified_state
 
 
-def test_revert_msg(evmtester, console_mode):
-    tx = evmtester.revertStrings(0)
-    assert tx.revert_msg == "zero"
-    tx = evmtester.revertStrings(1)
-    assert tx.revert_msg == "dev: one"
-    tx = evmtester.revertStrings(2)
-    assert tx.revert_msg == "two"
-    tx = evmtester.revertStrings(3)
-    assert tx.revert_msg == ""
-    tx = evmtester.revertStrings(31337)
-    assert tx.revert_msg == "dev: great job"
-
-
-def test_revert_msg_via_jump(ext_tester, console_mode):
-    tx = ext_tester.getCalled(2)
-    assert tx.revert_msg == "dev: should jump to a revert"
-
-
 def test_events(tester, console_mode):
     tx = tester.revertStrings(5)
     assert tx.status == 1

--- a/tests/network/transaction/test_revert_msg.py
+++ b/tests/network/transaction/test_revert_msg.py
@@ -1,0 +1,42 @@
+#!/usr/bin/python3
+
+import pytest
+
+from brownie.exceptions import VirtualMachineError
+
+
+def test_revert_msg_via_jump(ext_tester, console_mode):
+    tx = ext_tester.getCalled(2)
+    assert tx.revert_msg == "dev: should jump to a revert"
+
+
+def test_revert_msg(evmtester, console_mode):
+    tx = evmtester.revertStrings(0)
+    assert tx.revert_msg == "zero"
+    tx = evmtester.revertStrings(1)
+    assert tx.revert_msg == "dev: one"
+    tx = evmtester.revertStrings(2)
+    assert tx.revert_msg == "two"
+    tx = evmtester.revertStrings(3)
+    assert tx.revert_msg == ""
+    tx = evmtester.revertStrings(31337)
+    assert tx.revert_msg == "dev: great job"
+
+
+def test_nonpayable(tester, evmtester, console_mode):
+    tx = evmtester.revertStrings(0, {"value": 100})
+    assert tx.revert_msg == "Cannot send ether to nonpayable function"
+    tx = tester.doNothing({"value": 100})
+    assert tx.revert_msg == "Cannot send ether to nonpayable function"
+
+
+def test_invalid_opcodes(evmtester):
+    with pytest.raises(VirtualMachineError) as exc:
+        evmtester.invalidOpcodes(0, 0)
+    assert exc.value.revert_msg == "invalid opcode"
+    with pytest.raises(VirtualMachineError) as exc:
+        evmtester.invalidOpcodes(1, 1)
+    assert exc.value.revert_msg == "dev: foobar"
+    with pytest.raises(VirtualMachineError) as exc:
+        evmtester.invalidOpcodes(3, 3)
+    assert exc.value.revert_msg == "Index out of range"


### PR DESCRIPTION
- allow `dev:` revert comments for `assert` statements
- better error messages when sending ether to nonpayable function, or trying to access an invalid array index

closes #237 
closes #255 
closes #256 