### PR TITLE
Solc compiler edits and fixes

### DIFF
--- a/brownie/_config.py
+++ b/brownie/_config.py
@@ -106,11 +106,13 @@ def _load_project_config(project_path: Path) -> None:
     CONFIG._lock()
 
 
-def _load_project_compiler_config(project_path: Optional[Path], compiler: str) -> Dict:
+def _load_project_compiler_config(project_path: Optional[Path]) -> Dict:
     if not project_path:
-        return CONFIG["compiler"][compiler]
-    config_data = _load_config(project_path.joinpath("brownie-config"))
-    return config_data["compiler"][compiler]
+        return CONFIG["compiler"]
+    compiler_data = _load_config(project_path.joinpath("brownie-config"))["compiler"]
+    for key in [i for i in ("evm_version", "minify_source") if i not in compiler_data]:
+        compiler_data[key] = compiler_data["solc"].pop(key)
+    return compiler_data
 
 
 def _modify_network_config(network: str = None) -> Dict:

--- a/brownie/data/brownie-config.yaml
+++ b/brownie/data/brownie-config.yaml
@@ -38,12 +38,12 @@ pytest:
     reverting_tx_gas_limit: 6721975
     revert_traceback: false
 compiler:
+    evm_version: null
+    minify_source: false
     solc:
         version: null
-        evm_version: null
         optimize: true
         runs: 200
-        minify_source: false
 colors:
     key:
     value: bright blue

--- a/brownie/project/compiler/__init__.py
+++ b/brownie/project/compiler/__init__.py
@@ -128,7 +128,7 @@ def generate_input_json(
         if language == "Solidity":
             evm_version = next(i[0] for i in EVM_SOLC_VERSIONS if solidity.get_version() >= i[1])
         else:
-            evm_version = "byzantium"
+            evm_version = "petersburg"
 
     input_json: Dict = deepcopy(STANDARD_JSON)
     input_json["language"] = language

--- a/brownie/project/compiler/__init__.py
+++ b/brownie/project/compiler/__init__.py
@@ -81,8 +81,8 @@ def compile_and_format(
         else:
             compiler_targets[solc_version] = list(solc_sources)
 
-    compiler_data: Dict = {"minify_source": minify}
     for version, path_list in compiler_targets.items():
+        compiler_data: Dict = {"minify_source": minify}
         if version == "vyper":
             language = "Vyper"
             compiler_data["version"] = str(vyper.get_version())

--- a/brownie/project/compiler/solidity.py
+++ b/brownie/project/compiler/solidity.py
@@ -29,7 +29,7 @@ AVAILABLE_SOLC_VERSIONS = None
 
 
 def get_version() -> Version:
-    return solcx.get_solc_version()
+    return solcx.get_solc_version().truncate()
 
 
 def compile_from_input_json(

--- a/brownie/project/ethpm.py
+++ b/brownie/project/ethpm.py
@@ -564,24 +564,24 @@ def release_package(
 
 
 def _get_contract_type(build_json: Dict) -> Dict:
-    return {
+    contract_type = {
         "contract_name": build_json["contractName"],
         "source_path": f"./{Path(build_json['sourcePath']).relative_to('contracts')}",
         "deployment_bytecode": {"bytecode": f"0x{build_json['bytecode']}"},
         "runtime_bytecode": {"bytecode": f"0x{build_json['deployedBytecode']}"},
         "abi": build_json["abi"],
         "compiler": {
-            "name": "solc",
+            "name": "solc" if build_json["language"] == "Solidity" else "vyper",
             "version": build_json["compiler"]["version"],
-            "settings": {
-                "optimizer": {
-                    "enabled": build_json["compiler"]["optimize"],
-                    "runs": build_json["compiler"]["runs"],
-                },
-                "evmVersion": build_json["compiler"]["evm_version"],
-            },
+            "settings": {"evmVersion": build_json["compiler"]["evm_version"]},
         },
     }
+    if build_json["language"] == "Solidity":
+        contract_type["compiler"]["settings"]["optimizer"] = {
+            "enabled": build_json["compiler"]["optimize"],
+            "runs": build_json["compiler"]["runs"],
+        }
+    return contract_type
 
 
 def _load_packages_json(project_path: Path) -> Dict:

--- a/brownie/project/main.py
+++ b/brownie/project/main.py
@@ -361,11 +361,9 @@ def from_ethpm(uri: str) -> "TempProject":
 
     manifest = get_manifest(uri)
     compiler_config = {
-        "version": None,
-        "optimize": True,
-        "runs": 200,
         "evm_version": None,
         "minify_source": False,
+        "solc": {"version": None, "optimize": True, "runs": 200},
     }
     project = TempProject(manifest["package_name"], manifest["sources"], compiler_config)
     if web3.isConnected():
@@ -389,22 +387,17 @@ def _new_checks(project_path: Union[Path, str], ignore_subfolder: bool) -> Path:
 def compile_source(
     source: str,
     solc_version: Optional[str] = None,
-    optimize: Optional[bool] = True,
+    optimize: bool = True,
     runs: Optional[int] = 200,
-    evm_version: Optional[int] = None,
+    evm_version: Optional[str] = None,
 ) -> "TempProject":
     """Compiles the given source code string and returns a TempProject container with
     the ContractContainer instances."""
 
-    compiler_config = {
-        "version": solc_version,
-        "optimize": optimize,
-        "runs": runs,
-        "evm_version": evm_version,
-        "minify_source": False,
-    }
+    compiler_config: Dict = {"evm_version": evm_version, "minify_source": False}
 
     if solc_version is not None or source.lstrip().startswith("pragma"):
+        compiler_config["solc"] = {"version": solc_version, "optimize": optimize, "runs": runs}
         return TempProject("TempSolcProject", {"<stdin>.sol": source}, compiler_config)
 
     return TempProject("TempVyperProject", {"<stdin>.vy": source}, compiler_config)

--- a/docs/compile.rst
+++ b/docs/compile.rst
@@ -30,12 +30,12 @@ Settings for the compiler are found in ``brownie-config.yaml``:
 
 .. code-block:: yaml
 
+    evm_version: null
+    minify_source: false
     solc:
-        version: 0.5.10
-        evm_version: null
+        version: 0.6.0
         optimize: true
         runs: 200
-        minify_source: false
 
 Modifying any compiler settings will result in a full recompile of the project.
 
@@ -55,11 +55,11 @@ Setting the version via pragma allows you to use multiple versions in a single p
 The EVM Version
 ---------------
 
-By default, ``evm_version`` is set to ``null``. Brownie uses ``byzantium`` when compiling versions ``<=0.5.4`` and ``petersburg`` for ``>=0.5.5``.
+By default, ``evm_version`` is set to ``null``. Brownie uses ``byzantium`` when compiling Solidity versions ``<=0.5.4``, ``petersburg`` for Solidity ``>=0.5.5`` and Vyper.
 
-If you wish to use a newer compiler version on a network that has not yet forked you can set the EVM version manually. Valid options are ``byzantium``, ``constantinople`` and ``petersburg``.
+If you wish to use a specific compiler version you can set the EVM version manually. Valid options are ``byzantium``, ``constantinople``, ``petersburg`` and ``istanbul``.
 
-See the `Solidity documentation <https://solidity.readthedocs.io/en/latest/using-the-compiler.html#setting-the-evm-version-to-target>`_ for more info on the different EVM versions.
+See the `Solidity <https://solidity.readthedocs.io/en/latest/using-the-compiler.html#setting-the-evm-version-to-target>`_ and `Vyper <https://vyper.readthedocs.io/en/latest/compiling-a-contract.html#setting-the-target-evm-version>`_ documentation for more info on the different EVM versions.
 
 Compiler Optimization
 ---------------------

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -64,15 +64,16 @@ The following settings are available:
 
     Compiler settings. See :ref:`compiler settings<compile_settings>` for more information.
 
+    * ``evm_version``: The EVM version to compile for. If ``null`` the most recent one is used. Possible values are ``byzantium``, ``constantinople`` and ``petersburg``.
+    * ``minify_source``: If ``true``, contract source is minified before compiling.
+
     .. py:attribute:: compiler.solc
 
-        Settings specific to the Solidity compiler. At present this is the only compiler supported by Brownie.
+        Settings specific to the Solidity compiler.
 
         * ``version``: The version of solc to use. Should be given as a string in the format ``0.x.x``. If set to ``null``, the version is set based on the contract pragma. Brownie supports solc versions ``>=0.4.22``.
-        * ``evm_version``: The EVM version to compile for. If ``null`` the most recent one is used. Possible values are ``byzantium``, ``constantinople`` and ``petersburg``.
         * ``optimize``: Set to ``true`` if you wish to enable compiler optimization.
         * ``runs``: The number of times the optimizer should run.
-        * ``minify_source``: If ``true``, contract source is minified before compiling.
 
 .. py:attribute:: pytest
 

--- a/tests/project/compiler/test_solidity.py
+++ b/tests/project/compiler/test_solidity.py
@@ -51,10 +51,10 @@ def msolc(monkeypatch):
 
 def test_set_solc_version():
     compiler.set_solc_version("0.5.7")
-    assert solcx.get_solc_version() == compiler.solidity.get_version()
+    assert solcx.get_solc_version().truncate() == compiler.solidity.get_version()
     assert solcx.get_solc_version().truncate() == Version("0.5.7")
     compiler.set_solc_version("0.4.25")
-    assert solcx.get_solc_version() == compiler.solidity.get_version()
+    assert solcx.get_solc_version().truncate() == compiler.solidity.get_version()
     assert solcx.get_solc_version().truncate() == Version("0.4.25")
 
 

--- a/tests/project/compiler/test_vyper.py
+++ b/tests/project/compiler/test_vyper.py
@@ -31,7 +31,7 @@ def test_generate_input_json(vysource):
 
 def test_generate_input_json_evm(vysource):
     fn = functools.partial(compiler.generate_input_json, {"path.vy": vysource}, language="Vyper")
-    assert fn()["settings"]["evmVersion"] == "byzantium"
+    assert fn()["settings"]["evmVersion"] == "petersburg"
     assert fn(evm_version="byzantium")["settings"]["evmVersion"] == "byzantium"
     assert fn(evm_version="petersburg")["settings"]["evmVersion"] == "petersburg"
 


### PR DESCRIPTION
* reorganize the config file, `evm_version` and `minify_source` are not specific to `solc`
* do not require `solc` settings when a project has no solidity contracts - closes #297
* do not install `solc` until needed for compilation (previously it was done as soon as the config file was read)
* fix ethPM / vyper issues that were missed in #294
* updates to tests and documentation