### PR TITLE
bugfix: ensure accounts data subfolder exists

### DIFF
--- a/brownie/_cli/accounts.py
+++ b/brownie/_cli/accounts.py
@@ -33,6 +33,7 @@ scripts or the console using the Accounts.load method.
 
 def main():
     args = docopt(__doc__)
+    _get_data_folder().joinpath("accounts").mkdir(exist_ok=True)
     try:
         fn = getattr(sys.modules[__name__], f"_{args['<command>']}")
     except AttributeError:


### PR DESCRIPTION
### What was wrong / missing?
`~/.brownie/accounts` is never created when accessing the `brownie accounts` cli functionality. This can lead to a lot of errors with paths not existing.


### How was it fixed / added?
Create the path whenever `brownie accounts` is called, if it does not exist.

