### PR TITLE
feat: Add ETC and Kotti RPC endpoints to config

### DIFF
--- a/brownie/data/brownie-config.yaml
+++ b/brownie/data/brownie-config.yaml
@@ -31,6 +31,10 @@ network:
             host: https://rinkeby.infura.io/v3/$WEB3_INFURA_PROJECT_ID
         ropsten:
             host: https://ropsten.infura.io/v3/$WEB3_INFURA_PROJECT_ID
+        classic:
+            host: https://www.ethercluster.com/etc
+        kotti:
+            host: https://www.ethercluster.com/kotti
 pytest:
     # these settings replace the defaults when running pytest
     gas_limit: 6721975

--- a/tests/main/test_config.py
+++ b/tests/main/test_config.py
@@ -21,7 +21,7 @@ def test_network_keys(config):
         "rinkeby",
         "ropsten",
         "classic",
-        "kotti"
+        "kotti",
     }
 
 

--- a/tests/main/test_config.py
+++ b/tests/main/test_config.py
@@ -20,6 +20,8 @@ def test_network_keys(config):
         "kovan",
         "rinkeby",
         "ropsten",
+        "classic",
+        "kotti"
     }
 
 


### PR DESCRIPTION
### What was wrong / missing?
RPC Public endpoints for ETC and Kotti Testnet


### How was it fixed / added?
Add them to config file so it makes the tutorial I'm working on for Brownie easier to do.

