### PR TITLE
Add Ethereum Classic rulesets

### DIFF
--- a/brownie/_config.py
+++ b/brownie/_config.py
@@ -16,6 +16,8 @@ DATA_FOLDER = Path.home().joinpath(".brownie")
 
 REPLACE = ["active_network", "networks"]
 
+EVM_EQUIVALENTS = {"atlantis": "byzantium", "agharta": "petersburg"}
+
 
 class ConfigDict(dict):
     """Dict subclass that prevents adding new keys when locked"""

--- a/brownie/network/rpc.py
+++ b/brownie/network/rpc.py
@@ -11,6 +11,7 @@ from urllib.parse import urlparse
 
 import psutil
 
+from brownie._config import EVM_EQUIVALENTS
 from brownie._singleton import _Singleton
 from brownie.exceptions import RPCConnectionError, RPCProcessError, RPCRequestError
 
@@ -72,6 +73,8 @@ class Rpc(metaclass=_Singleton):
             else:
                 cmd += ".cmd"
         kwargs.setdefault("evm_version", EVM_DEFAULT)  # type: ignore
+        if kwargs["evm_version"] in EVM_EQUIVALENTS:
+            kwargs["evm_version"] = EVM_EQUIVALENTS[kwargs["evm_version"]]  # type: ignore
         for key, value in [(k, v) for k, v in kwargs.items() if v]:
             cmd += f" {CLI_FLAGS[key]} {value}"
         print(f"Launching '{cmd}'...")
@@ -212,6 +215,7 @@ class Rpc(metaclass=_Singleton):
         the currently active EVM version."""
         if not self.is_active():
             raise RPCRequestError("RPC is not active")
+        version = EVM_EQUIVALENTS.get(version, version)
         try:
             return EVM_VERSIONS.index(version) <= EVM_VERSIONS.index(  # type: ignore
                 self.evm_version()

--- a/brownie/project/compiler/solidity.py
+++ b/brownie/project/compiler/solidity.py
@@ -12,6 +12,7 @@ from requests.exceptions import ConnectionError
 from semantic_version import NpmSpec, Version
 from solcast.nodes import NodeBase
 
+from brownie._config import EVM_EQUIVALENTS
 from brownie.exceptions import CompilerError, IncompatibleSolcVersion, PragmaError
 from brownie.project.compiler.utils import expand_source_map
 
@@ -49,6 +50,8 @@ def compile_from_input_json(
 
     optimizer = input_json["settings"]["optimizer"]
     input_json["settings"].setdefault("evmVersion", None)
+    if input_json["settings"]["evmVersion"] in EVM_EQUIVALENTS:
+        input_json["settings"]["evmVersion"] = EVM_EQUIVALENTS[input_json["settings"]["evmVersion"]]
 
     if not silent:
         print("Compiling contracts...")

--- a/docs/compile.rst
+++ b/docs/compile.rst
@@ -57,7 +57,7 @@ The EVM Version
 
 By default, ``evm_version`` is set to ``null``. Brownie uses ``byzantium`` when compiling Solidity versions ``<=0.5.4``, ``petersburg`` for Solidity ``>=0.5.5`` and Vyper.
 
-If you wish to use a specific compiler version you can set the EVM version manually. Valid options are ``byzantium``, ``constantinople``, ``petersburg`` and ``istanbul``.
+You can also set the EVM version manually. Valid options are ``byzantium``, ``constantinople``, ``petersburg`` and ``istanbul``. You can also use the Ethereum Classic rulesets ``atlantis`` and ``agharta``, which are converted to their Ethereum equivalents prior to being passed to the compiler.
 
 See the `Solidity <https://solidity.readthedocs.io/en/latest/using-the-compiler.html#setting-the-evm-version-to-target>`_ and `Vyper <https://vyper.readthedocs.io/en/latest/compiling-a-contract.html#setting-the-target-evm-version>`_ documentation for more info on the different EVM versions.
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -64,7 +64,7 @@ The following settings are available:
 
     Compiler settings. See :ref:`compiler settings<compile_settings>` for more information.
 
-    * ``evm_version``: The EVM version to compile for. If ``null`` the most recent one is used. Possible values are ``byzantium``, ``constantinople`` and ``petersburg``.
+    * ``evm_version``: The EVM version to compile for. If ``null`` the most recent one is used. Possible values are ``byzantium``, ``constantinople``, ``petersburg``, ``istanbul``, ``atlantis`` and ``agharta``.
     * ``minify_source``: If ``true``, contract source is minified before compiling.
 
     .. py:attribute:: compiler.solc

--- a/tests/network/rpc/test_evm.py
+++ b/tests/network/rpc/test_evm.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from brownie._config import EVM_EQUIVALENTS
 from brownie.exceptions import RPCRequestError
 
 
@@ -28,3 +29,12 @@ def test_evm_compatible(monkeypatch, rpc):
     assert not rpc.evm_compatible("petersburg")
     with pytest.raises(ValueError):
         rpc.evm_compatible("potato")
+
+
+@pytest.mark.parametrize("original,translated", EVM_EQUIVALENTS.items())
+def test_evm_equivalents(no_rpc, temp_port, original, translated):
+    assert not no_rpc.is_active()
+    no_rpc.launch("ganache-cli", port=temp_port, evm_version=original)
+    assert no_rpc.is_active()
+    assert no_rpc.evm_version() == translated
+    no_rpc.kill()

--- a/tests/project/compiler/test_solidity.py
+++ b/tests/project/compiler/test_solidity.py
@@ -6,6 +6,7 @@ import pytest
 import solcx
 from semantic_version import Version
 
+from brownie._config import EVM_EQUIVALENTS
 from brownie.exceptions import CompilerError, IncompatibleSolcVersion, PragmaError
 from brownie.project import build, compiler
 
@@ -92,6 +93,13 @@ def test_compile_input_json_raises():
     input_json = compiler.generate_input_json({"path.sol": "potato"}, True, 200)
     with pytest.raises(CompilerError):
         compiler.compile_from_input_json(input_json)
+
+
+@pytest.mark.parametrize("original,translated", EVM_EQUIVALENTS.items())
+def test_compile_input_json_evm_translates(solc5source, original, translated):
+    compiler.set_solc_version("0.5.7")
+    input_json = compiler.generate_input_json({"path.sol": solc5source}, True, 200, original)
+    compiler.compile_from_input_json(input_json)
 
 
 def test_compile_optimizer(monkeypatch):


### PR DESCRIPTION
* Allow use of `atlantis` and `agharta` in the config file.
