### PR TITLE
Use zero gas price on development network

### DIFF
--- a/brownie/data/brownie-config.yaml
+++ b/brownie/data/brownie-config.yaml
@@ -3,14 +3,15 @@
 network:
     default: development # the default network that brownie connects to
     settings:
-        gas_limit: false
-        gas_price: false
+        gas_limit: "auto"
+        gas_price: "auto"
         persist: true
         reverting_tx_gas_limit: false  # if false, reverting tx's will raise without broadcasting
     networks:
         # any settings given here will replace the defaults
         development:
             host: http://127.0.0.1
+            gas_price: 0
             persist: false
             reverting_tx_gas_limit: 6721975
             test_rpc:

--- a/brownie/network/account.py
+++ b/brownie/network/account.py
@@ -191,12 +191,16 @@ class _PrivateKeyAccount(PublicKeyAccount):
     """Base class for Account and LocalAccount"""
 
     def _gas_limit(self, to: Union[str, "Accounts"], amount: Optional[int], data: str = "") -> int:
-        if CONFIG["active_network"]["gas_limit"] not in (True, False, None):
-            return Wei(CONFIG["active_network"]["gas_limit"])
-        return self.estimate_gas(to, amount, data)
+        gas_limit = CONFIG["active_network"]["gas_limit"]
+        if isinstance(gas_limit, bool) or gas_limit in (None, "auto"):
+            return self.estimate_gas(to, amount, data)
+        return Wei(gas_limit)
 
     def _gas_price(self) -> Wei:
-        return Wei(CONFIG["active_network"]["gas_price"] or web3.eth.gasPrice)
+        gas_price = CONFIG["active_network"]["gas_price"]
+        if isinstance(gas_price, bool) or gas_price in (None, "auto"):
+            return web3.eth.gasPrice
+        return Wei(gas_price)
 
     def _check_for_revert(self, tx: Dict) -> None:
         if not CONFIG["active_network"]["reverting_tx_gas_limit"]:
@@ -284,8 +288,8 @@ class _PrivateKeyAccount(PublicKeyAccount):
         self,
         to: "Accounts",
         amount: int,
-        gas_limit: float = None,
-        gas_price: float = None,
+        gas_limit: int = None,
+        gas_price: int = None,
         data: str = "",
     ) -> "TransactionReceipt":
         """Transfers ether from this account.

--- a/brownie/network/main.py
+++ b/brownie/network/main.py
@@ -84,12 +84,12 @@ def gas_limit(*args: Tuple[Union[int, str, bool, None]]) -> Union[int, bool]:
     """Gets and optionally sets the default gas limit.
 
     * If an integer value is given, this will be the default gas limit.
-    * If set to None, True or False, the gas limit is determined
-    automatically."""
+    * If set to 'auto', the gas limit is determined automatically."""
+
     if not is_connected():
         raise ConnectionError("Not connected to any network")
     if args:
-        if args[0] in (None, False, True):
+        if args[0] in (None, False, True, "auto"):
             CONFIG["active_network"]["gas_limit"] = False
         else:
             try:
@@ -106,12 +106,12 @@ def gas_price(*args: Tuple[Union[int, str, bool, None]]) -> Union[int, bool]:
     """Gets and optionally sets the default gas price.
 
     * If an integer value is given, this will be the default gas price.
-    * If set to None, True or False, the gas price is determined
-    automatically."""
+    * If set to 'auto', the gas price is determined automatically."""
+
     if not is_connected():
         raise ConnectionError("Not connected to any network")
     if args:
-        if args[0] in (None, False, True):
+        if args[0] in (None, False, True, "auto"):
             CONFIG["active_network"]["gas_price"] = False
         else:
             try:

--- a/docs/api-network.rst
+++ b/docs/api-network.rst
@@ -62,7 +62,7 @@ The ``main`` module contains methods for conncting to or disconnecting from the 
 
     * If no argument is given, the current default is displayed.
     * If an integer value is given, this will be the default gas limit.
-    * If set to ``None``, ``True`` or ``False``, the gas limit is determined automatically via ``web3.eth.estimateGas``.
+    * If set to ``auto``, the gas limit is determined automatically via ``web3.eth.estimateGas``.
 
     Returns ``False`` if the gas limit is set automatically, or an ``int`` if it is set to a fixed value.
 
@@ -73,7 +73,7 @@ The ``main`` module contains methods for conncting to or disconnecting from the 
         False
         >>> network.gas_limit(6700000)
         6700000
-        >>> network.gas_limit(None)
+        >>> network.gas_limit("auto")
         False
 
 .. py:method:: main.gas_price(*args: Tuple[Union[int, str, bool, None]]) -> Union[int, bool]
@@ -81,7 +81,7 @@ The ``main`` module contains methods for conncting to or disconnecting from the 
     Gets and optionally sets the default gas price.
 
     * If an integer value is given, this will be the default gas price.
-    * If set to ``None``, ``True`` or ``False``, the gas price is determined automatically via ``web3.eth.getPrice``.
+    * If set to ``auto``, the gas price is determined automatically via ``web3.eth.getPrice``.
 
     Returns ``False`` if the gas price is set automatically, or an ``int`` if it is set to a fixed value.
 
@@ -94,7 +94,7 @@ The ``main`` module contains methods for conncting to or disconnecting from the 
         10000000000
         >>> network.gas_price("1.2 gwei")
         1200000000
-        >>> network.gas_price(False)
+        >>> network.gas_price("auto")
         False
 
 ``brownie.network.account``

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -33,8 +33,8 @@ The following settings are available:
 
         Default settings for every network. The following properties can be set:
 
-        * ``gas_price``: The default gas price for all transactions. If left as ``false`` the gas price will be determined using ``web3.eth.gasPrice``.
-        * ``gas_limit``: The default gas limit for all transactions. If left as ``false`` the gas limit will be determined using ``web3.eth.estimateGas``.
+        * ``gas_price``: The default gas price for all transactions. If set to ``auto`` the gas price will be determined using ``web3.eth.gasPrice``.
+        * ``gas_limit``: The default gas limit for all transactions. If set to ``auto`` the gas limit will be determined using ``web3.eth.estimateGas``.
         * ``persist``: If ``True``, Brownie will remember information about deployed contracts in between sessions. This is enabled by default for all non-local networks.
         * ``reverting_tx_gas_limit``: The gas limit to use when a transaction would revert. If set to ``false``, transactions that would revert will instead raise a ``VirtualMachineError``.
 

--- a/tests/network/account/test_account_deploy.py
+++ b/tests/network/account/test_account_deploy.py
@@ -43,9 +43,10 @@ def test_gas_price_manual(BrownieTester, accounts):
     assert accounts[0].balance() == balance - (tx.gas_used * 100)
 
 
-def test_gas_price_automatic(BrownieTester, accounts, config, web3):
+@pytest.mark.parametrize("auto", (True, False, None, "auto"))
+def test_gas_price_automatic(BrownieTester, accounts, config, web3, auto):
     """gas price is set correctly using web3.eth.gasPrice"""
-    config["active_network"]["gas_price"] = False
+    config["active_network"]["gas_price"] = auto
     balance = accounts[0].balance()
     tx = accounts[0].deploy(BrownieTester, True).tx
     assert tx.gas_price == web3.eth.gasPrice
@@ -61,15 +62,25 @@ def test_gas_price_config(BrownieTester, accounts, config, web3):
     assert accounts[0].balance() == balance - (50 * tx.gas_used)
 
 
+def test_gas_price_zero(BrownieTester, accounts, config, web3):
+    """gas price is set correctly from the config"""
+    config["active_network"]["gas_price"] = 0
+    balance = accounts[0].balance()
+    tx = accounts[0].deploy(BrownieTester, True).tx
+    assert tx.gas_price == 0
+    assert accounts[0].balance() == balance
+
+
 def test_gas_limit_manual(BrownieTester, accounts):
     """gas limit is set correctly when specified in the call"""
     tx = accounts[0].deploy(BrownieTester, True, gas_limit=3000000).tx
     assert tx.gas_limit == 3000000
 
 
-def test_gas_limit_automatic(BrownieTester, accounts, config):
+@pytest.mark.parametrize("auto", (True, False, None, "auto"))
+def test_gas_limit_automatic(BrownieTester, accounts, config, auto):
     """gas limit is set correctly using web3.eth.estimateGas"""
-    config["active_network"]["gas_limit"] = False
+    config["active_network"]["gas_limit"] = auto
     tx = accounts[0].deploy(BrownieTester, True).tx
     assert tx.gas_limit == tx.gas_used
 

--- a/tests/network/account/test_account_transfer.py
+++ b/tests/network/account/test_account_transfer.py
@@ -99,9 +99,10 @@ def test_gas_price_manual(accounts):
     assert accounts[0].balance() == balance - (100 * 21000)
 
 
-def test_gas_price_automatic(accounts, config, web3):
+@pytest.mark.parametrize("auto", (True, False, None, "auto"))
+def test_gas_price_automatic(accounts, config, web3, auto):
     """gas price is set correctly using web3.eth.gasPrice"""
-    config["active_network"]["gas_price"] = False
+    config["active_network"]["gas_price"] = auto
     balance = accounts[0].balance()
     tx = accounts[0].transfer(accounts[1], 0)
     assert tx.gas_price == web3.eth.gasPrice
@@ -117,6 +118,14 @@ def test_gas_price_config(accounts, config):
     assert accounts[0].balance() == balance - (50 * 21000)
 
 
+def test_gas_price_zero(accounts, config):
+    config["active_network"]["gas_price"] = 0
+    balance = accounts[0].balance()
+    tx = accounts[0].transfer(accounts[1], 1337)
+    assert tx.gas_price == 0
+    assert accounts[0].balance() == balance - 1337
+
+
 def test_gas_limit_manual(accounts):
     """gas limit is set correctly when specified in the call"""
     tx = accounts[0].transfer(accounts[1], 1000, gas_limit=100000)
@@ -124,9 +133,10 @@ def test_gas_limit_manual(accounts):
     assert tx.gas_used == 21000
 
 
-def test_gas_limit_automatic(accounts, config):
+@pytest.mark.parametrize("auto", (True, False, None, "auto"))
+def test_gas_limit_automatic(accounts, config, auto):
     """gas limit is set correctly using web3.eth.estimateGas"""
-    config["active_network"]["gas_limit"] = False
+    config["active_network"]["gas_limit"] = auto
     tx = accounts[0].transfer(accounts[1], 1000)
     assert tx.gas_limit == 21000
 

--- a/tests/network/contract/test_contractconstructor.py
+++ b/tests/network/contract/test_contractconstructor.py
@@ -43,9 +43,10 @@ def test_gas_price_manual(BrownieTester, accounts):
     assert accounts[0].balance() == balance - (tx.gas_used * 100)
 
 
-def test_gas_price_automatic(BrownieTester, accounts, config, web3):
+@pytest.mark.parametrize("auto", (True, False, None, "auto"))
+def test_gas_price_automatic(BrownieTester, accounts, config, web3, auto):
     """gas price is set correctly using web3.eth.gasPrice"""
-    config["active_network"]["gas_price"] = False
+    config["active_network"]["gas_price"] = auto
     balance = accounts[0].balance()
     tx = BrownieTester.deploy(True, {"from": accounts[0]}).tx
     assert tx.gas_price == web3.eth.gasPrice
@@ -67,9 +68,10 @@ def test_gas_limit_manual(BrownieTester, accounts):
     assert tx.gas_limit == 3000000
 
 
-def test_gas_limit_automatic(BrownieTester, accounts, config):
+@pytest.mark.parametrize("auto", (True, False, None, "auto"))
+def test_gas_limit_automatic(BrownieTester, accounts, config, auto):
     """gas limit is set correctly using web3.eth.estimateGas"""
-    config["active_network"]["gas_limit"] = False
+    config["active_network"]["gas_limit"] = auto
     tx = BrownieTester.deploy(True, {"from": accounts[0]}).tx
     assert tx.gas_limit == tx.gas_used
 

--- a/tests/network/contract/test_contracttx.py
+++ b/tests/network/contract/test_contracttx.py
@@ -121,9 +121,10 @@ def test_gas_price_manual(tester, accounts):
     assert accounts[0].balance() == balance - (100 * tx.gas_used)
 
 
-def test_gas_price_automatic(tester, accounts, config, web3):
+@pytest.mark.parametrize("auto", (True, False, None, "auto"))
+def test_gas_price_automatic(tester, accounts, config, web3, auto):
     """gas price is set correctly using web3.eth.gasPrice"""
-    config["active_network"]["gas_price"] = False
+    config["active_network"]["gas_price"] = auto
     balance = accounts[0].balance()
     tx = tester.doNothing({"from": accounts[0]})
     assert tx.gas_price == web3.eth.gasPrice
@@ -145,9 +146,10 @@ def test_gas_limit_manual(tester, accounts):
     assert tx.gas_limit == 100000
 
 
-def test_gas_limit_automatic(tester, accounts, config):
+@pytest.mark.parametrize("auto", (True, False, None, "auto"))
+def test_gas_limit_automatic(tester, accounts, config, auto):
     """gas limit is set correctly using web3.eth.estimateGas"""
-    config["active_network"]["gas_limit"] = False
+    config["active_network"]["gas_limit"] = auto
     tx = tester.doNothing({"from": accounts[0]})
     assert tx.gas_limit == tx.gas_used
 


### PR DESCRIPTION
### What I did
* Modify default `gas_price` for development network to zero.
* Change `gas_price` and `gas_limit` from bools to `auto` to be more explicit.

Closes #315

### How I did it
* Changes to how the config settings are evaluated in `brownie/network/account.py`
* Updated defult config file

### How to verify it
Run the tests.  I added some new test cases and modified existing ones to verify these changes.

### Checklist
- [x] I have confirmed that my PR passes all linting checks
- [x] I have included test cases
- [x] I have updated the documentation
- [ ] I have added an entry to the changelog
