### PR TITLE
Set istanbul as default EVM ruleset

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,14 +11,14 @@ jobs:
         - sudo apt-get update
         - sudo apt-get install -y python3.7-dev npm solc
       script: tox -e evmtest
-    - name: "Standard Tests, Plugin Tests - Python 3.8 on Windows"
+    - name: "Standard Tests - Python 3.8 on Windows"
       os: windows
       language: node_js
       node_js: '10'
       before_install:
         - choco install python --version=3.8.0
       env: PATH=/c/Python38:/c/Python38/Scripts:$PATH
-      script: tox -e py38,plugintest
+      script: tox -e py38
     - name: "Standard Tests, Linting, Docs - Python 3.6 on Xenial Linux"
       language: python
       python: 3.6
@@ -54,7 +54,7 @@ env:
   global: COVERALLS_PARALLEL=true
 install:
   - python -m pip install --upgrade pip setuptools
-  - npm -g install ganache-cli@6.7.0
+  - npm -g install ganache-cli@6.8.2
   - python -m pip install coveralls==1.9.2 tox==3.14.0
 after_script: python -m coveralls
 notifications:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Move check for new contract sources from `Project.__init__` to `Project.load`
+- Set `istanbul` as default EVM ruleset, run tests against `ganache-cli` [v6.8.2](https://github.com/trufflesuite/ganache-cli/releases/tag/v6.8.2)
 
 ### Deprecated
 - `pytest.reverts` is deprecated in favor of `brownie.reverts`
@@ -28,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Accept `atlantis` and `agharta` as EVM ruleset options in `brownie-config.yaml`
 
 ### Changed
-- Use Vyper version 0.1.0b16
+- Use Vyper [v0.1.0-beta16](https://github.com/vyperlang/vyper/releases/tag/v0.1.0-beta.16)
 
 ### Fixed
 - Create `~/.brownie/accounts` when `accounts` commandline interface is called
@@ -62,7 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.3.0](https://github.com/iamdefinitelyahuman/brownie/tree/v1.3.0) - 2019-12-20
 ### Added
-- support for [Solidity v0.6.0](https://github.com/ethereum/solidity/releases/tag/v0.6.0)
+- support for Solidity [v0.6.0](https://github.com/ethereum/solidity/releases/tag/v0.6.0)
 - allow `istanbul` as choice for EVM ruleset (default is still `petersburg`)
 - allow `dev:` revert comments for `assert` statements
 - better error messages when sending ether to nonpayable function, or trying to access an invalid array index

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Brownie is a Python-based development and testing framework for smart contracts 
 
 ## Dependencies
 
-* [ganache-cli](https://github.com/trufflesuite/ganache-cli) - tested with version [6.7.0](https://github.com/trufflesuite/ganache-cli/releases/tag/v6.7.0)
+* [ganache-cli](https://github.com/trufflesuite/ganache-cli) - tested with version [6.8.2](https://github.com/trufflesuite/ganache-cli/releases/tag/v6.8.2)
 * [pip](https://pypi.org/project/pip/)
 * [python3](https://www.python.org/downloads/release/python-368/) version 3.6 or greater, python3-dev
 

--- a/brownie/data/brownie-config.yaml
+++ b/brownie/data/brownie-config.yaml
@@ -19,7 +19,7 @@ network:
                 port: 8545
                 gas_limit: 6721975
                 accounts: 10
-                evm_version: petersburg
+                evm_version: istanbul
                 mnemonic: brownie
         # set your Infura API token to the environment variable WEB3_INFURA_PROJECT_ID
         mainnet:

--- a/brownie/network/rpc.py
+++ b/brownie/network/rpc.py
@@ -27,7 +27,7 @@ CLI_FLAGS = {
 }
 
 EVM_VERSIONS = ["byzantium", "constantinople", "petersburg", "istanbul"]
-EVM_DEFAULT = "petersburg"
+EVM_DEFAULT = "istanbul"
 
 __tracebackhide__ = True
 _revert_refs: List = []

--- a/brownie/project/compiler/__init__.py
+++ b/brownie/project/compiler/__init__.py
@@ -30,7 +30,7 @@ STANDARD_JSON: Dict = {
     },
 }
 EVM_SOLC_VERSIONS = [
-    # ("istanbul", Version("0.5.13")),  # TODO enable when ganache istanbul support is out of beta
+    ("istanbul", Version("0.5.13")),
     ("petersburg", Version("0.5.5")),
     ("byzantium", Version("0.4.0")),
 ]
@@ -149,7 +149,7 @@ def generate_input_json(
         if language == "Solidity":
             evm_version = next(i[0] for i in EVM_SOLC_VERSIONS if solidity.get_version() >= i[1])
         else:
-            evm_version = "petersburg"
+            evm_version = "istanbul"
 
     input_json: Dict = deepcopy(STANDARD_JSON)
     input_json["language"] = language

--- a/docs/api-network.rst
+++ b/docs/api-network.rst
@@ -1439,7 +1439,7 @@ Rpc Methods
     .. code-block:: python
 
         >>> rpc.evm_version()
-        'petersburg'
+        'istanbul'
 
 .. py:classmethod:: Rpc.evm_compatible(version)
 

--- a/docs/compile.rst
+++ b/docs/compile.rst
@@ -68,7 +68,11 @@ Setting the version via pragma allows you to use multiple versions in a single p
 The EVM Version
 ---------------
 
-By default, ``evm_version`` is set to ``null``. Brownie uses ``byzantium`` when compiling Solidity versions ``<=0.5.4``, ``petersburg`` for Solidity ``>=0.5.5`` and Vyper.
+By default ``evm_version`` is set to ``null``. Brownie sets the ruleset based on the compiler:
+
+* **byzantium**: Solidity ``<=0.5.4``
+* **petersburg**: Solidity ``>=0.5.5 <=0.5.12``
+* **istanbul**: Solidity ``>=0.5.13``, Vyper
 
 You can also set the EVM version manually. Valid options are ``byzantium``, ``constantinople``, ``petersburg`` and ``istanbul``. You can also use the Ethereum Classic rulesets ``atlantis`` and ``agharta``, which are converted to their Ethereum equivalents prior to being passed to the compiler.
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -54,7 +54,7 @@ The following settings are available:
             * ``port``: Port the client should listen on.
             * ``gas_limit``: Block gas limit.
             * ``accounts``: The number of funded accounts in ``web3.eth.accounts``.
-            * ``evm_version``: The EVM version to compile for. If ``null`` the most recent one is used. Possible values are ``byzantium``, ``constantinople`` and ``petersburg``.
+            * ``evm_version``: The EVM version to compile for. If ``null`` the most recent one is used. Possible values are ``byzantium``, ``constantinople``, ``petersburg`` and ``istanbul``.
             * ``mnemonic``: Local accounts are derived from this mnemonic. If set to ``null``, you will have different local accounts each time Brownie is run.
             * ``account_keys_path``: Optional path to save generated accounts and private keys as a JSON object
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -30,11 +30,11 @@ Dependencies
 
 Brownie has the following dependencies:
 
-* `ganache-cli <https://github.com/trufflesuite/ganache-cli>`__
-* `pip <https://pypi.org/project/pip/>`__
-* `python3 <https://www.python.org/downloads/release/python-368/>`__ version 3.6 or greater, python3-dev
+* `ganache-cli <https://github.com/trufflesuite/ganache-cli>`_ - tested with version `6.8.2 <https://github.com/trufflesuite/ganache-cli/releases/tag/v6.8.2>`_
+* `pip <https://pypi.org/project/pip/>`_
+* `python3 <https://www.python.org/downloads/release/python-368/>`_ version 3.6 or greater, python3-dev
 
-As brownie relies on `py-solc-x <https://github.com/iamdefinitelyahuman/py-solc-x>`__, you do not need solc installed locally but you must install all required `solc dependencies <https://solidity.readthedocs.io/en/latest/installing-solidity.html#binary-packages>`__.
+As brownie relies on `py-solc-x <https://github.com/iamdefinitelyahuman/py-solc-x>`_, you do not need solc installed locally but you must install all required `solc dependencies <https://solidity.readthedocs.io/en/latest/installing-solidity.html#binary-packages>`_.
 
 
 .. _install-tk:

--- a/docs/test-rpc.rst
+++ b/docs/test-rpc.rst
@@ -21,7 +21,7 @@ The connection settings for the local RPC are outlined in ``brownie-config.yaml`
             port: 8545
             gas_limit: 6721975
             accounts: 10
-            evm_version: petersburg
+            evm_version: istanbul
             mnemonic: brownie
 
 Brownie will launch or attach to the client when using any network that includes a ``test-rpc`` dictionary in it's settings.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,15 +59,17 @@ def pytest_generate_tests(metafunc):
     # parametrize the evmtester fixture
     target = metafunc.config.getoption("--target")
     if "evmtester" in metafunc.fixturenames and target in ("all", "evm"):
-        metafunc.parametrize(
-            "evmtester",
+        params = list(
             itertools.product(
-                ["byzantium", "constantinople"],
-                [0, 200, 10000],
-                ["0.4.22", "0.4.25", "0.5.0", "0.5.15", "0.6.0"],
-            ),
-            indirect=True,
+                ["byzantium", "constantinople"], [0, 10000], ["0.4.22", "0.4.25", "0.5.0"]
+            )
         )
+        params += list(
+            itertools.product(
+                ["byzantium", "petersburg", "istanbul"], [0, 10000], ["0.5.15", "0.6.0"]
+            )
+        )
+        metafunc.parametrize("evmtester", params, indirect=True)
 
     # parametrize the browniemix fixture
     if "browniemix" in metafunc.fixturenames and target in ("all", "mixes"):

--- a/tests/network/rpc/test_evm.py
+++ b/tests/network/rpc/test_evm.py
@@ -19,7 +19,7 @@ def test_evm_version_default(monkeypatch, rpc):
     monkeypatch.setattr("psutil.Popen.cmdline", lambda s: ["--hardfork", "otatop"])
     assert rpc.evm_version() == "otatop"
     monkeypatch.setattr("psutil.Popen.cmdline", lambda s: ["--hardfork"])
-    assert rpc.evm_version() == "petersburg"
+    assert rpc.evm_version() == "istanbul"
 
 
 def test_evm_compatible(monkeypatch, rpc):

--- a/tests/project/compiler/test_vyper.py
+++ b/tests/project/compiler/test_vyper.py
@@ -31,7 +31,7 @@ def test_generate_input_json(vysource):
 
 def test_generate_input_json_evm(vysource):
     fn = functools.partial(compiler.generate_input_json, {"path.vy": vysource}, language="Vyper")
-    assert fn()["settings"]["evmVersion"] == "petersburg"
+    assert fn()["settings"]["evmVersion"] == "istanbul"
     assert fn(evm_version="byzantium")["settings"]["evmVersion"] == "byzantium"
     assert fn(evm_version="petersburg")["settings"]["evmVersion"] == "petersburg"
 


### PR DESCRIPTION
### What I did
* Set `istanbul` as default EVM ruleset
* Update test cases
* Bump tested `ganache-cli` version to 6.8.2

Closes #276 

### How to verify it
Run the tests.  EVM tests now include `istanbul` in the parametrization.
