### PR TITLE
Deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/iamdefinitelyahuman/brownie)
 ### Added
 - [Hypothesis](https://github.com/HypothesisWorks/hypothesis/tree/master/hypothesis-python) integration for property-based and stateful testing
+- `TransactionReceipt.new_contracts` - list of contracts deployed during a contract call
 
 ### Changed
 - Refactor `brownie.convert` into sub-modules
 - Use `eth_abi.grammar.parse` when formatting contract inputs and outputs
 - Replace [`docopt`](https://github.com/docopt/docopt) with [`docopt-ng`](https://github.com/bazaar-projects/docopt-ng) (fixes deprecation warnings)
+- `ContractContainer.at` compares actual bytecode to expected, returns `Contract` object if they do not match
 
 ### Fixed
 - bug preventing `pytest.default_contract_owner` config setting from having any effect
+- threading exception when contract deployment fails
 
 ## [1.5.1](https://github.com/iamdefinitelyahuman/brownie/tree/v1.5.1) - 2020-01-21
 ### Fixed

--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -7,6 +7,7 @@ from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Union
 
 import eth_abi
 from eth_hash.auto import keccak
+from eth_utils import remove_0x_prefix
 from hexbytes import HexBytes
 
 from brownie._config import ARGV, CONFIG
@@ -146,7 +147,8 @@ class ContractContainer(_ContractBase):
 
     def _add_from_tx(self, tx: TransactionReceiptType) -> None:
         tx._confirmed.wait()
-        self.at(tx.contract_address, tx.sender, tx)
+        if tx.status:
+            self.at(tx.contract_address, tx.sender, tx)
 
 
 class ContractConstructor:
@@ -555,6 +557,7 @@ def _signature(abi: Dict) -> str:
 
 def _verify_deployed_code(address: str, expected_bytecode: str) -> bool:
     actual_bytecode = web3.eth.getCode(address).hex()[2:]
+    expected_bytecode = remove_0x_prefix(expected_bytecode)
 
     if expected_bytecode.startswith("730000000000000000000000000000000000000000"):
         # special case for Solidity libraries

--- a/brownie/network/transaction.py
+++ b/brownie/network/transaction.py
@@ -305,7 +305,7 @@ class TransactionReceipt:
             f"{color['key']}Gas used{color}: {color['value']}{self.gas_used}{color} "
             f"({color['value']}{self.gas_used / self.gas_limit:.2%}{color})"
         )
-        if self.contract_address:
+        if self.status and self.contract_address:
             result += (
                 f"\n  {self.contract_name} deployed at: "
                 f"{color['value']}{self.contract_address}{color}"
@@ -386,7 +386,7 @@ class TransactionReceipt:
                 if trace[i]["pc"] != step["pc"] - 4:
                     step = trace[i]
             self._revert_msg = pc_map[step["pc"]]["dev"]
-        except KeyError:
+        except (KeyError, AttributeError):
             self._revert_msg = "invalid opcode" if step["op"] == "INVALID" else ""
 
     def _expand_trace(self) -> None:

--- a/brownie/network/transaction.py
+++ b/brownie/network/transaction.py
@@ -78,6 +78,7 @@ class TransactionReceipt:
         "_confirmed",
         "_events",
         "_modified_state",
+        "_new_contracts",
         "_raw_trace",
         "_return_value",
         "_revert_msg",
@@ -134,6 +135,7 @@ class TransactionReceipt:
         self._return_value = None
         self._revert_msg = None
         self._modified_state = None
+        self._new_contracts = None
         self._confirmed = threading.Event()
 
         self.sender = sender
@@ -203,6 +205,14 @@ class TransactionReceipt:
         elif self._modified_state is None:
             self._get_trace()
         return self._modified_state
+
+    @trace_property
+    def new_contracts(self) -> Optional[List]:
+        if not self.status:
+            return []
+        if self._new_contracts is None:
+            self._expand_trace()
+        return self._new_contracts
 
     @trace_property
     def return_value(self) -> Optional[str]:
@@ -397,6 +407,7 @@ class TransactionReceipt:
         if self._raw_trace is None:
             self._get_trace()
         self._trace = trace = self._raw_trace
+        self._new_contracts = []
         if not trace:
             coverage._add_transaction(self.coverage_hash, {})
             return
@@ -410,13 +421,18 @@ class TransactionReceipt:
         for i in range(len(trace)):
             # if depth has increased, tx has called into a different contract
             if trace[i]["depth"] > trace[i - 1]["depth"]:
-                # get call signature
-                stack_idx = -4 if trace[i - 1]["op"] in {"CALL", "CALLCODE"} else -3
-                offset = int(trace[i - 1]["stack"][stack_idx], 16) * 2
-                sig = HexBytes("".join(trace[i - 1]["memory"])[offset : offset + 8]).hex()
-
-                # get contract and method name
-                address = trace[i - 1]["stack"][-2][-40:]
+                if trace[i - 1]["op"] in ("CREATE", "CREATE2"):
+                    # creating a new contract
+                    step = next(x for x in trace[i:] if x["depth"] == trace[i - 1]["depth"])
+                    address = step["stack"][-1][-40:]
+                    sig = f"<{trace[i-1]['op']}>"
+                    self._new_contracts.append(EthAddress(address))
+                else:
+                    # calling an existing contract
+                    stack_idx = -4 if trace[i - 1]["op"] in ("CALL", "CALLCODE") else -3
+                    offset = int(trace[i - 1]["stack"][stack_idx], 16) * 2
+                    sig = HexBytes("".join(trace[i - 1]["memory"])[offset : offset + 8]).hex()
+                    address = trace[i - 1]["stack"][-2][-40:]
 
                 last_map[trace[i]["depth"]] = _get_last_map(address, sig)
                 coverage_eval.setdefault(last_map[trace[i]["depth"]]["name"], {})

--- a/brownie/network/web3.py
+++ b/brownie/network/web3.py
@@ -89,7 +89,7 @@ class Web3(_Web3):
         if self.provider is None:
             raise ConnectionError("web3 is not currently connected")
         if self.genesis_hash not in _chain_uri_cache:
-            block_number = max(self.eth.blockNumber - 16, 1)
+            block_number = max(self.eth.blockNumber - 16, 0)
             block_hash = self.eth.getBlock(block_number)["hash"].hex()[2:]
             chain_uri = f"blockchain://{self.genesis_hash}/block/{block_hash}"
             _chain_uri_cache[self.genesis_hash] = chain_uri

--- a/brownie/project/main.py
+++ b/brownie/project/main.py
@@ -23,7 +23,7 @@ from brownie._config import (
 from brownie.exceptions import ProjectAlreadyLoaded, ProjectNotFound
 from brownie.network import web3
 from brownie.network.contract import ContractContainer, ProjectContract
-from brownie.network.state import _remove_contract
+from brownie.network.state import _add_contract, _remove_contract
 from brownie.project import compiler
 from brownie.project.build import BUILD_KEYS, Build
 from brownie.project.ethpm import get_deployment_addresses, get_manifest
@@ -253,6 +253,7 @@ class Project(_ProjectBase):
             else:
                 container = self._containers[build["contractName"]]
                 contract = ProjectContract(self, build, build_json.stem)
+                _add_contract(contract)
                 container._contracts.append(contract)
 
     def _update_and_register(self, dict_: Any) -> None:

--- a/brownie/project/main.py
+++ b/brownie/project/main.py
@@ -22,7 +22,7 @@ from brownie._config import (
 )
 from brownie.exceptions import ProjectAlreadyLoaded, ProjectNotFound
 from brownie.network import web3
-from brownie.network.contract import ContractContainer, ProjectContract
+from brownie.network.contract import Contract, ContractContainer, ProjectContract
 from brownie.network.state import _add_contract, _remove_contract
 from brownie.project import compiler
 from brownie.project.build import BUILD_KEYS, Build
@@ -250,11 +250,17 @@ class Project(_ProjectBase):
                 build = json.load(fp)
             if build["contractName"] not in self._containers:
                 build_json.unlink()
-            else:
-                container = self._containers[build["contractName"]]
+                continue
+            if "pcMap" in build:
                 contract = ProjectContract(self, build, build_json.stem)
-                _add_contract(contract)
-                container._contracts.append(contract)
+            else:
+                contract = Contract(  # type: ignore
+                    build["contractName"], build_json.stem, build["abi"]
+                )
+                contract._project = self
+            container = self._containers[build["contractName"]]
+            _add_contract(contract)
+            container._contracts.append(contract)
 
     def _update_and_register(self, dict_: Any) -> None:
         dict_.update(self)

--- a/docs/api-network.rst
+++ b/docs/api-network.rst
@@ -647,14 +647,14 @@ ContractContainer Methods
 
 .. py:classmethod:: ContractContainer.at(address, owner=None)
 
-    Returns a :func:`ProjectContract <brownie.network.contract.ProjectContract>` instance.
+    Returns a new :func:`Contract <brownie.network.contract.ProjectContract>` or :func:`ProjectContract <brownie.network.contract.ProjectContract>` object. The object is also appended to the container.
 
-    * ``address``: Address where the contract is deployed. Raises a ``ValueError`` if there is no bytecode at the address.
+    * ``address``: Address where the contract is deployed.
     * ``owner``: :func:`Account <brownie.network.account.Account>` instance to set as the contract owner. If transactions to the contract do not specify a ``'from'`` value, they will be sent from this account.
 
-    .. note::
+    This method compares the bytecode at the given address with the deployment bytecode for the given :func:`ContractContainer <brownie.network.contract.ContractContainer>`. A :func:`ProjectContract <brownie.network.contract.ProjectContract>` is returned if the bytecodes match, a :func:`Contract <brownie.network.contract.ProjectContract>` otherwise.
 
-        This method checks for the existence of bytecode at the given address, but does not check if the bytecode matches that of the :func:`ContractContainer <brownie.network.contract.ContractContainer>`.
+    Raises :func:`ContractNotFound <brownie.exceptions.ContractNotFound>` if there is no code at the given address.
 
     .. code-block:: python
 
@@ -1568,7 +1568,7 @@ TransactionReceipt Attributes
 
 .. py:attribute:: TransactionReceipt.contract_address
 
-    The address of the contract deployed as a result of this transaction, if any.
+    The address of the contract deployed in this transaction, if the transaction was a deployment.
 
     .. code-block:: python
 
@@ -1576,6 +1576,8 @@ TransactionReceipt Attributes
         <Transaction object '0xac54b49987a77805bf6bdd78fb4211b3dc3d283ff0144c231a905afa75a06db0'>
         >>> tx.contract_address
         None
+
+    For contracts deployed as the result of calling another contract, see :func:`TransactionReceipt.new_contracts <TransactionReceipt.new_contracts>`.
 
 .. py:attribute:: TransactionReceipt.contract_name
 
@@ -1684,6 +1686,21 @@ TransactionReceipt Attributes
         <Transaction object '0xac54b49987a77805bf6bdd78fb4211b3dc3d283ff0144c231a905afa75a06db0'>
         >>> tx.modified_state
         True
+
+.. py:attribute:: TransactionReceipt.new_contracts
+
+    A list of new contract addresses that were deployed during this transaction, as the result of contract call.
+
+    .. code-block:: python
+
+        >>> tx = Deployer.deploy_new_contract()
+        Transaction sent: 0x6c3183e41670101c4ab5d732bfe385844815f67ae26d251c3bd175a28604da92
+          Gas price: 0.0 gwei   Gas limit: 79781
+          Deployer.deploy_new_contract confirmed - Block: 4   Gas used: 79489 (99.63%)
+
+        >>> tx.new_contracts
+        ["0x1262567B3e2e03f918875370636dE250f01C528c"]
+
 
 .. py:attribute:: TransactionReceipt.nonce
 

--- a/docs/core-transactions.rst
+++ b/docs/core-transactions.rst
@@ -41,8 +41,8 @@ To view human-readable information on a transaction, call the :func:`Transaction
 
 .. _event-data:
 
-Accessing Event Data
-====================
+Event Data
+==========
 
 Data about events is available as :func:`TransactionReceipt.events <TransactionReceipt.events>`. It is stored in an :func:`EventDict <brownie.network.event.EventDict>` object; a hybrid container with both dict-like and list-like properties.
 
@@ -110,6 +110,30 @@ Or as a list when the sequence is important, or more than one event of the same 
         'permitted': True
     }
 
+Deployment Data
+===============
+
+:func:`TransactionReceipt.new_contracts <TransactionReceipt.new_contracts>` provides a list of addresses for any new contracts that were created during a transaction. This is useful when you are using a factory pattern.
+
+.. code-block:: python
+
+    >>> tx = Deployer.deploy_new_token()
+    Transaction sent: 0x6c3183e41670101c4ab5d732bfe385844815f67ae26d251c3bd175a28604da92
+      Gas price: 0.0 gwei   Gas limit: 79781
+      Deployer.deploy_new_contract confirmed - Block: 4   Gas used: 79489 (99.63%)
+
+    >>> tx.new_contracts
+    ["0x1262567B3e2e03f918875370636dE250f01C528c"]
+
+To generate :func:`Contract <brownie.network.contract.ProjectContract>` objects from this list, use :func:`ContractContainer.at <ContractContainer.at>`:
+
+.. code-block:: python
+
+    >>> tx.new_contracts
+    ["0x1262567B3e2e03f918875370636dE250f01C528c"]
+    >>> Token.at(tx.new_contracts[0])
+    <Token Contract object '0x1262567B3e2e03f918875370636dE250f01C528c'>
+
 .. _debug:
 
 Debugging Failed Transactions
@@ -156,8 +180,8 @@ You can also call :func:`TransactionReceipt.traceback <TransactionReceipt.traceb
         File "contracts/SecurityToken.sol", line 136, in SecurityToken._checkTransfer:
         require(balances[_addr[SENDER]] >= _value, "Insufficient Balance");
 
-Inspecting the Transaction Trace
-================================
+Inspecting the Trace
+====================
 
 The Trace Object
 ----------------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -96,7 +96,7 @@ def pytest_sessionstart():
     monkeypatch_session = MonkeyPatch()
     monkeypatch_session.setattr(
         "solcx.get_available_solc_versions",
-        lambda: ["v0.6.0", "v0.5.15", "v0.5.8", "v0.5.7", "v0.4.25", "v0.4.24", "v0.4.22"],
+        lambda: ["v0.6.2", "v0.5.15", "v0.5.8", "v0.5.7", "v0.4.25", "v0.4.24", "v0.4.22"],
     )
 
 

--- a/tests/network/contract/test_contract.py
+++ b/tests/network/contract/test_contract.py
@@ -22,9 +22,14 @@ def build(testproject):
     yield deepcopy(build)
 
 
-def test_type(tester):
+def test_type_solidity(tester):
     assert type(tester) is ProjectContract
     assert isinstance(tester, _DeployedContractBase)
+
+
+def test_type_vyper(vypertester):
+    assert type(vypertester) is ProjectContract
+    assert isinstance(vypertester, _DeployedContractBase)
 
 
 def test_namespace_collision(tester, build):

--- a/tests/network/contract/test_contractcontainer.py
+++ b/tests/network/contract/test_contractcontainer.py
@@ -2,6 +2,8 @@
 
 import pytest
 
+from brownie.network.contract import Contract, ProjectContract
+
 
 def test_get_method(BrownieTester):
     calldata = "0x2e27149600000000000000000000000066ab6d9362d4f35596279692f0251db635165871"
@@ -54,6 +56,14 @@ def test_remove_at(BrownieTester, accounts):
         BrownieTester.remove(t2)
     with pytest.raises(TypeError):
         BrownieTester.remove(123)
+
+
+def test_at_checks_bytecode(BrownieTester, ExternalCallTester, accounts):
+    t = BrownieTester.deploy(True, {"from": accounts[0]})
+    del BrownieTester[0]
+    assert type(BrownieTester.at(t.address)) is ProjectContract
+    del BrownieTester[0]
+    assert type(ExternalCallTester.at(t.address)) is Contract
 
 
 def test_load_unload_project(BrownieTester, testproject, rpc, accounts):

--- a/tests/network/contract/test_multiple_projects.py
+++ b/tests/network/contract/test_multiple_projects.py
@@ -19,9 +19,9 @@ def test_deploy(BrownieTester, otherproject, accounts):
 def test_at_remove(BrownieTester, otherproject, accounts):
     t = otherproject.BrownieTester.deploy(True, {"from": accounts[0]})
     with pytest.raises(ContractExists):
-        BrownieTester.at(t)
+        BrownieTester.at(t.address)
     otherproject.BrownieTester.remove(t)
-    BrownieTester.at(t)
+    BrownieTester.at(t.address)
 
 
 def test_interaction(tester, otherproject, accounts):

--- a/tests/network/contract/test_unlinked_library.py
+++ b/tests/network/contract/test_unlinked_library.py
@@ -3,6 +3,12 @@
 import pytest
 
 from brownie.exceptions import UndeployedLibrary
+from brownie.network.contract import ProjectContract
+
+
+def test_library_is_project_contract(accounts, librarytester):
+    lib = accounts[0].deploy(librarytester["TestLib"])
+    assert type(lib) is ProjectContract
 
 
 def test_unlinked_library(accounts, librarytester):

--- a/tests/network/transaction/test_new_contracts.py
+++ b/tests/network/transaction/test_new_contracts.py
@@ -1,0 +1,104 @@
+#!/usr/bin/python3
+
+import pytest
+
+from brownie.network.contract import Contract, ProjectContract
+
+solidity_source = """
+pragma solidity 0.6.2;
+
+contract Foo {
+
+    constructor (bool _fail) public {
+        require(!_fail);
+    }
+
+    function foo () public view returns (uint256) { return 42; }
+}
+
+contract Deployer {
+
+    function create (bool _fail) public returns (Foo) {
+        return new Foo(_fail);
+    }
+
+    function create2 (bool _fail) public returns (Foo) {
+        bytes32 _salt = 0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef;
+        return new Foo{salt: _salt}(_fail);
+    }
+}
+
+"""
+
+
+@pytest.fixture
+def solcproject(newproject, accounts):
+    with newproject._path.joinpath("contracts/Test.sol").open("w") as fp:
+        fp.write(solidity_source)
+    newproject.load()
+
+    newproject.Deployer.deploy({"from": accounts[0]})
+    yield newproject
+
+
+def test_solidity_create(solcproject):
+    deployer = solcproject.Deployer[0]
+    tx = deployer.create(False)
+
+    tx.call_trace()
+    assert len(tx.new_contracts) == 1
+    foo = solcproject.Foo.at(tx.new_contracts[0])
+    assert type(foo) is ProjectContract
+    assert foo.foo() == 42
+
+
+def test_solidity_create2(solcproject):
+    deployer = solcproject.Deployer[0]
+    tx = deployer.create2(False)
+
+    tx.call_trace()
+    assert len(tx.new_contracts) == 1
+    foo = solcproject.Foo.at(tx.new_contracts[0])
+    assert type(foo) is ProjectContract
+    assert foo.foo() == 42
+
+
+def test_solidity_reverts(solcproject, console_mode):
+    deployer = solcproject.Deployer[0]
+    tx = deployer.create(True)
+
+    tx.call_trace()
+    assert len(tx.new_contracts) == 0
+
+
+vyper_forwarder_source = """
+
+@public
+def create_new(_target: address) -> address:
+    return create_forwarder_to(_target)
+"""
+
+vyper_factory_source = """
+
+@public
+@constant
+def foo() -> uint256:
+    return 42
+"""
+
+
+def test_vyper_create_forwarder_to(newproject, accounts):
+    with newproject._path.joinpath("contracts/Forwarder.vy").open("w") as fp:
+        fp.write(vyper_forwarder_source)
+    with newproject._path.joinpath("contracts/Foo.vy").open("w") as fp:
+        fp.write(vyper_factory_source)
+    newproject.load()
+
+    foo = newproject.Foo.deploy({"from": accounts[0]})
+    forwarder = newproject.Forwarder.deploy({"from": accounts[0]})
+    tx = forwarder.create_new(foo)
+
+    assert len(tx.new_contracts) == 1
+    foo2 = newproject.Foo.at(tx.new_contracts[0])
+    assert type(foo2) is Contract
+    assert foo2.foo() == 42

--- a/tests/network/transaction/test_trace.py
+++ b/tests/network/transaction/test_trace.py
@@ -86,6 +86,18 @@ def test_modified_state_revert(console_mode, tester):
     assert tx.modified_state is False
 
 
+def test_new_contracts(console_mode, tester):
+    tx = tester.doNothing()
+    assert tx.new_contracts == []
+    assert tx._expand_trace.call_count
+
+
+def test_new_contracts_reverts(console_mode, tester):
+    tx = tester.revertStrings(1)
+    assert tx.new_contracts == []
+    assert not tx._trace
+
+
 def test_trace(tester):
     """getting the trace also evaluates the trace"""
     tx = tester.doNothing()

--- a/tests/project/compiler/test_solidity.py
+++ b/tests/project/compiler/test_solidity.py
@@ -183,9 +183,9 @@ def test_find_solc_versions_install(find_version, msolc):
     find_version("^0.4.22", install_latest=True)
     assert msolc.pop() == "v0.4.25"
     find_version("^0.4.24 || >=0.5.10", install_needed=True)
-    assert msolc.pop() == "v0.6.0"
+    assert msolc.pop() == "v0.6.2"
     find_version(">=0.4.24", install_latest=True)
-    assert msolc.pop() == "v0.6.0"
+    assert msolc.pop() == "v0.6.2"
 
 
 def test_install_solc(msolc):


### PR DESCRIPTION
### What I did
Detect contracts that are deployed via contract calls.

Closes #238 

### How I did it
1. Added `TransactionReceipt.new_contracts`, a list of addresses of deployments. This information is gathered during `TransactionReceipt._expand_trace`.
2. `ContractContainer.at` compares actual bytecode at an address against the expected bytecode. If there is a difference, it returns `Contract` instead of `ProjectContract`. This avoids various issues with traces and coverage evaluation when using Vyper's `create_forwarder_to`.
3. Fix minor pre-existing bugs related to failed contract deployments.

### How to verify it
Run the tests. I included new test cases, this functionality is verified using `create_forwarder_to` in Vyper and `new` in Solidity (with both `CREATE` and `CREATE2`).

### Checklist
- [x] I have confirmed that my PR passes all linting checks
- [x] I have included test cases
- [x] I have updated the documentation
- [x] I have added an entry to the changelog