### PR TITLE
Internal transfers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [Hypothesis](https://github.com/HypothesisWorks/hypothesis/tree/master/hypothesis-python) integration for property-based and stateful testing
 - `TransactionReceipt.new_contracts` - list of contracts deployed during a contract call
+- `TransactionReceipt.internal_transfers` - information on internal ether transfers during a transaction
 
 ### Changed
 - Refactor `brownie.convert` into sub-modules

--- a/brownie/network/transaction.py
+++ b/brownie/network/transaction.py
@@ -534,7 +534,7 @@ class TransactionReceipt:
             f"{color['key']}From{color}: {color['value']}{self.sender}\n"
         )
 
-        if self.contract_address:
+        if self.contract_address and self.status:
             result += (
                 f"{color['key']}New {self.contract_name} address{color}: "
                 f"{color['value']}{self.contract_address}\n"
@@ -544,7 +544,7 @@ class TransactionReceipt:
                 f"{color['key']}To{color}: {color['value']}{self.receiver}{color}\n"
                 f"{color['key']}Value{color}: {color['value']}{self.value}\n"
             )
-            if int(self.input, 16):
+            if self.input != "0x" and int(self.input, 16):
                 result += f"{color['key']}Function{color}: {color['value']}{self._full_name()}\n"
 
         result += (

--- a/docs/api-network.rst
+++ b/docs/api-network.rst
@@ -1664,6 +1664,26 @@ TransactionReceipt Attributes
         >>> tx.input
         '0xa9059cbb00000000000000000000000031d504908351d2d87f3d6111f491f0b52757b592000000000000000000000000000000000000000000000000000000000000000a'
 
+.. py:attribute:: TransactionReceipt.internal_transfers
+
+    A list of all internal ether transfers that occurred during the transaction. Transfers are sequenced in the order they took place, and represented as dictionaries containing the following fields:
+
+    * ``from``: Sender address
+    * ``to``: Receiver address
+    * ``value``: Amount of ether that was transferred in :func:`Wei <brownie.convert.datatypes.Wei>`
+
+    .. code-block:: python
+
+        >>> tx
+        <Transaction object '0xac54b49987a77805bf6bdd78fb4211b3dc3d283ff0144c231a905afa75a06db0'>
+        >>> tx.internal_transfers
+        [
+            {
+                "from": "0x79447c97b6543F6eFBC91613C655977806CB18b0",
+                "to": "0x21b42413bA931038f35e7A5224FaDb065d297Ba3",
+                "value": 100
+            }
+        ]
 
 .. py:attribute:: TransactionReceipt.logs
 

--- a/docs/core-transactions.rst
+++ b/docs/core-transactions.rst
@@ -110,8 +110,21 @@ Or as a list when the sequence is important, or more than one event of the same 
         'permitted': True
     }
 
-Deployment Data
-===============
+Internal Transactions and Deployments
+=====================================
+
+:func:`TransactionReceipt.internal_transfers <TransactionReceipt.new_contracts>` provides a list of internal ether transfers that occurred during the transaction.
+
+.. code-block:: python
+
+        >>> tx.internal_transfers
+        [
+            {
+                "from": "0x79447c97b6543F6eFBC91613C655977806CB18b0",
+                "to": "0x21b42413bA931038f35e7A5224FaDb065d297Ba3",
+                "value": 100
+            }
+        ]
 
 :func:`TransactionReceipt.new_contracts <TransactionReceipt.new_contracts>` provides a list of addresses for any new contracts that were created during a transaction. This is useful when you are using a factory pattern.
 

--- a/tests/network/transaction/test_internal_transfer.py
+++ b/tests/network/transaction/test_internal_transfer.py
@@ -1,0 +1,93 @@
+#!/usr/bin/python3
+
+from brownie import Wei, compile_source
+from brownie.convert import EthAddress
+
+
+def test_to_eoa(accounts):
+    container = compile_source(
+        """
+@public
+@payable
+def send_ether(receivers: address[3]) -> bool:
+    value: uint256 =100
+    for i in range(3):
+        send(receivers[i], value)
+        value += 100
+    return True"""
+    ).Vyper
+    contract = container.deploy({"from": accounts[0]})
+    tx = contract.send_ether(accounts[:3], {"value": 800})
+    assert tx.internal_transfers == [
+        {"from": contract, "to": accounts[0], "value": 100},
+        {"from": contract, "to": accounts[1], "value": 200},
+        {"from": contract, "to": accounts[2], "value": 300},
+    ]
+
+
+def test_to_contract(accounts):
+    container = compile_source(
+        """
+@public
+@payable
+def send_ether(receiver: address) -> bool:
+    send(receiver, msg.value)
+    return True
+
+@public
+@payable
+def __default__():
+    return
+    """
+    ).Vyper
+    contract = container.deploy({"from": accounts[0]})
+    contract2 = container.deploy({"from": accounts[0]})
+    tx = contract.send_ether(contract2, {"value": 31337})
+
+    assert tx.internal_transfers == [{"from": contract, "to": contract2, "value": 31337}]
+
+
+def test_types(accounts):
+    container = compile_source(
+        """
+@public
+@payable
+def send_ether(receiver: address) -> bool:
+    send(receiver, msg.value)
+    return True"""
+    ).Vyper
+    contract = container.deploy({"from": accounts[0]})
+    tx = contract.send_ether(accounts[1], {"value": 800})
+    xfer = tx.internal_transfers[0]
+    assert type(xfer["from"]) is EthAddress
+    assert type(xfer["to"]) is EthAddress
+    assert type(xfer["value"]) is Wei
+
+
+def test_via_create_vyper(accounts):
+    container = compile_source(
+        """
+@public
+@payable
+def send_ether() -> bool:
+    create_forwarder_to(self, value=msg.value)
+    return True"""
+    ).Vyper
+    contract = container.deploy({"from": accounts[0]})
+    tx = contract.send_ether({"value": 42})
+    assert tx.internal_transfers == [{"from": contract, "to": tx.new_contracts[0], "value": 42}]
+
+
+def test_via_create_solidity(accounts):
+    project = compile_source(
+        """pragma solidity 0.6.2;
+
+contract Foo { constructor () public payable {} }
+
+contract Deployer {
+    function create () public payable returns (Foo) { return new Foo{value: msg.value}(); }
+}"""
+    )
+    contract = project.Deployer.deploy({"from": accounts[0]})
+    tx = contract.create({"value": 69})
+    assert tx.internal_transfers == [{"from": contract, "to": tx.new_contracts[0], "value": 69}]

--- a/tests/network/transaction/test_trace.py
+++ b/tests/network/transaction/test_trace.py
@@ -98,6 +98,18 @@ def test_new_contracts_reverts(console_mode, tester):
     assert not tx._trace
 
 
+def test_internal_xfers(tester):
+    tx = tester.doNothing()
+    assert tx.internal_transfers == []
+    assert tx._expand_trace.call_count
+
+
+def test_internal_xfers_reverts(console_mode, tester):
+    tx = tester.revertStrings(1)
+    assert tx.internal_transfers == []
+    assert not tx._trace
+
+
 def test_trace(tester):
     """getting the trace also evaluates the trace"""
     tx = tester.doNothing()


### PR DESCRIPTION
### What I did
Provide information on internal transfers during transactions.

Closes: #342

### How I did it
1. Add a `TransactionReceipt.internal_transfers` member that makes use of `@trace_property`
2. Scan the trace for `CALL` and `CREATE` opcodes with an non-zero value and record as dictionaries of `{'from', 'to', 'value'}` within `internal_transfers`.
3. Minor bugfix around transfers to fallback functions.

### How to verify it
Run the tests.

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [x] I have included test cases
- [x] I have updated the documentation
- [x] I have added an entry to the changelog
