### PR TITLE
use intersphinx, various minor docs fixes and improvements

### DIFF
--- a/docs/api-test.rst
+++ b/docs/api-test.rst
@@ -139,7 +139,7 @@ One of these classes is instantiated in the ``pytest_configure`` method of ``bro
 RevertContextManager
 --------------------
 
-The ``RevertContextManager`` closely mimics the behaviour of `pytest.raises <https://docs.pytest.org/en/latest/reference.html#pytest-raises>`_.
+The ``RevertContextManager`` closely mimics the behaviour of :func:`pytest.raises <pytest.raises>`.
 
 .. py:class:: brownie.test.plugin.RevertContextManager(revert_msg=None)
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -10,9 +10,9 @@ If you have not yet viewed the documentation under "Core Functionality" within t
 
 .. hint::
 
-    From the console you can call the builtin ``dir`` method to see available methods and attributes for any class. Classes, methods and attributes are highlighted in different colors.
+    From the console you can call the builtin :func:`dir <dir>` method to see available methods and attributes for any class. Classes, methods and attributes are highlighted in different colors.
 
-     You can also call ``help`` on any class or method to view information on it's functionality.
+     You can also call :func:`help <help>` on any class or method to view information on it's functionality.
 
 .. toctree::
     :maxdepth: 2

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,7 +49,7 @@ release = "v1.6.1"
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions: List = []
+extensions: List = ["sphinx.ext.intersphinx"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
@@ -179,3 +179,9 @@ epub_title = project
 
 # A list of files that should not be packed into the epub file.
 epub_exclude_files = ["search.html"]
+
+intersphinx_mapping = {
+    "hypothesis": ("https://hypothesis.readthedocs.io/en/latest", None),
+    "pytest": ("https://docs.pytest.org/en/latest/", None),
+    "python": ("https://docs.python.org/3.8/", None),
+}

--- a/docs/core-accounts.rst
+++ b/docs/core-accounts.rst
@@ -24,11 +24,14 @@ Each individual account is represented by an :func:`Account <brownie.network.acc
 
 The :func:`Account.balance <Account.balance>` method is used to check the balance of an account. The value returned is denominated in :func:`wei <brownie.convert.datatypes.Wei>`.
 
+.. code-block:: python
 
     >>> accounts[1].balance()
     100000000000000000000
 
 The :func:`Account.transfer <Account.transfer>` method is used to send ether between accounts and perform other simple transactions. As shown in the example below, the amount to transfer may be specified as a string that is converted by :func:`Wei <brownie.convert.datatypes.Wei>`.
+
+.. code-block:: python
 
     >>> accounts[0].transfer(accounts[1], "10 ether")
 

--- a/docs/ethpm.rst
+++ b/docs/ethpm.rst
@@ -22,13 +22,13 @@ Registry URIs
 
 To obtain an ethPM package, you must know both the package name and the address of the registry where it is available. The simplest way to communicate this information is through a `registry URI <https://docs.ethpm.com/uris#registry-uris>`_. Registry URIs adhere to the following format:
 
-.. code-block::
+::
 
     erc1319://[CONTRACT_ADDRESS]:[CHAIN_ID]/[PACKAGE_NAME]@[VERSION]
 
 For example, here is a registry URI for the popular OpenZeppelin `Math <https://github.com/OpenZeppelin/openzeppelin-contracts/tree/master/contracts/math>`_ package, served by the Snake Charmers `Zeppelin registry <http://explorer.ethpm.com/browse/mainnet/zeppelin.snakecharmers.eth>`_:
 
-.. code-block::
+::
 
     erc1319://zeppelin.snakecharmers.eth:1/math@1.0.0
 

--- a/docs/interaction.rst
+++ b/docs/interaction.rst
@@ -27,9 +27,9 @@ Brownie will compile the contracts, launch or attach to the :ref:`local test env
 
 .. hint::
 
-    You can call the builtin ``dir`` method to see available methods and attributes for any class. Classes, methods and attributes are highlighted in different colors.
+    You can call the builtin :func:`dir <dir>` method to see available methods and attributes for any class. Classes, methods and attributes are highlighted in different colors.
 
-    You can also call ``help`` on any class or method to view information on it's functionality.
+    You can also call :func:`help <help>` on any class or method to view information on it's functionality.
 
 .. _scripts:
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -89,9 +89,9 @@ Brownie will compile your contracts, start the local RPC client, and give you a 
 
 .. hint::
 
-    You can call the builtin ``dir`` method to see available methods and attributes for any class. Classes, methods and attributes are highlighted in different colors.
+    You can call the builtin :func:`dir <dir>` method to see available methods and attributes for any class. Classes, methods and attributes are highlighted in different colors.
 
-    You can also call ``help`` on any class or method to view information on it's functionality.
+    You can also call :func:`help <help>` on any class or method to view information on it's functionality.
 
 Accounts
 --------
@@ -286,7 +286,7 @@ A complete list of Brownie fixtures is available here.
 Handling Reverted Transactions
 ------------------------------
 
-Transactions that revert raise a :func:`VirtualMachineError <brownie.exceptions.VirtualMachineError>` exception. To write assertions around this you can use :func:`brownie.reverts <brownie.test.plugin.RevertContextManager>` as a context manager, which functions very similarly to ``pytest.raises``:
+Transactions that revert raise a :func:`VirtualMachineError <brownie.exceptions.VirtualMachineError>` exception. To write assertions around this you can use :func:`brownie.reverts <brownie.test.plugin.RevertContextManager>` as a context manager, which functions very similarly to :func:`pytest.raises <pytest.raises>`:
 
 .. code-block:: python
     :linenos:

--- a/docs/tests-hypothesis-property.rst
+++ b/docs/tests-hypothesis-property.rst
@@ -33,7 +33,7 @@ To begin writing property-based tests, import the following two methods:
 
     from brownie.test import given, strategy
 
-* ``given`` is a decorator that converts a test function that accepts arguments into a randomized test. This is a thin wrapper around `hypothesis.given <https://hypothesis.readthedocs.io/en/latest/details.html#hypothesis.given>`_, the API is identical.
+* ``given`` is a decorator that converts a test function that accepts arguments into a randomized test. This is a thin wrapper around :func:`hypothesis.given <hypothesis.given>`, the API is identical.
 * ``strategy`` is a method for creating :ref:`test strategies<hypothesis-strategies>` based on ABI types.
 
 A test using Hypothesis consists of two parts: A function that looks like a normal pytest test with some additional arguments, and a ``@given`` decorator that specifies how to those arguments are provided.
@@ -113,7 +113,7 @@ The following strategies correspond to types within `Solidity <https://solidity.
 Address
 *******
 
-    `Base strategy:` `hypothesis.strategies.sampled_from <https://hypothesis.readthedocs.io/en/latest/data.html#hypothesis.strategies.sampled_from>`_
+    `Base strategy:` :func:`hypothesis.strategies.sampled_from <hypothesis.strategies.sampled_from>`
 
 ``address`` strategies yield :func:`Account <brownie.network.account.Account>` objects from the :func:`Accounts <brownie.network.account.Accounts>` container.
 
@@ -132,7 +132,7 @@ Optional keyword arguments:
 Bool
 ****
 
-    `Base strategy:` `hypothesis.strategies.booleans <https://hypothesis.readthedocs.io/en/latest/data.html#hypothesis.strategies.booleans>`_
+    `Base strategy:` :func:`hypothesis.strategies.booleans <hypothesis.strategies.booleans>`
 
 ``bool`` strategies yield ``True`` or ``False``.
 
@@ -149,7 +149,7 @@ This strategy does not accept any keyword arguments.
 Bytes
 *****
 
-    `Base strategy:` `hypothesis.strategies.binary <https://hypothesis.readthedocs.io/en/latest/data.html#hypothesis.strategies.binary>`_
+    `Base strategy:` :func:`hypothesis.strategies.binary <hypothesis.strategies.binary>`
 
 ``bytes`` strategies yield byte strings.
 
@@ -175,7 +175,7 @@ For `fixed length values <https://solidity.readthedocs.io/en/latest/types.html#f
 Decimal
 *******
 
-    `Base strategy:` `hypothesis.strategies.decimals <https://hypothesis.readthedocs.io/en/latest/data.html#hypothesis.strategies.decimals>`_
+    `Base strategy:` :func:`hypothesis.strategies.decimals <hypothesis.strategies.decimals>`
 
 ``decimal`` strategies yield ``decimal.Decimal`` instances.
 
@@ -198,7 +198,7 @@ Optional keyword arguments:
 Integer
 *******
 
-    `Base strategy:` `hypothesis.strategies.integers <https://hypothesis.readthedocs.io/en/latest/data.html#hypothesis.strategies.integers>`_
+    `Base strategy:` :func:`hypothesis.strategies.integers <hypothesis.strategies.integers>`
 
 ``int`` and ``uint`` strategies yield integer values.
 
@@ -223,7 +223,7 @@ Optional keyword arguments:
 String
 ******
 
-    `Base strategy:` `hypothesis.strategies.text <https://hypothesis.readthedocs.io/en/latest/data.html#hypothesis.strategies.text>`_
+    `Base strategy:` :func:`hypothesis.strategies.text <hypothesis.strategies.text>`
 
 ``string`` strategies yield unicode text strings.
 
@@ -251,7 +251,7 @@ Along with the core strategies, Brownie also offers strategies for generating ar
 Array
 *****
 
-    `Base strategy:` `hypothesis.strategies.lists <https://hypothesis.readthedocs.io/en/latest/data.html#hypothesis.strategies.lists>`_
+    `Base strategy:` :func:`hypothesis.strategies.lists <hypothesis.strategies.lists>`
 
 Array strategies yield lists of strategies for the base array type. It is possible to generate arrays of both fixed and dynamic length, as well as multidimensional arrays.
 
@@ -278,7 +278,7 @@ You can also include keyword arguments for the base type of the array. They will
 Tuple
 *****
 
-    `Base strategy:` `hypothesis.strategies.tuples <https://hypothesis.readthedocs.io/en/latest/data.html#hypothesis.strategies.tuples>`_
+    `Base strategy:` :func:`hypothesis.strategies.tuples <hypothesis.strategies.tuples>`
 
 Tuple strategies yield tuples of mixed strategies according to the given type string.
 
@@ -308,7 +308,7 @@ Settings
 
 Depending on the scope and complexity of your tests, it may be necessary to modify the default settings for how property-based tests are run.
 
-The mechanism for doing this is the ``hypothesis.settings`` object. You can set up a ``@given`` based test to use this using a settings decorator:
+The mechanism for doing this is the :py:class:`hypothesis.settings <hypothesis.settings>` object. You can set up a ``@given`` based test to use this using a settings decorator:
 
 
 .. code-block:: python

--- a/docs/tests-pytest-fixtures.rst
+++ b/docs/tests-pytest-fixtures.rst
@@ -8,7 +8,7 @@ Pytest Fixtures Reference
 Brownie provides :ref:`fixtures <pytest-fixtures-docs>` to allow you to interact with your project during tests. To use a fixture, add an argument with the same name to the inputs of your test function.
 
 Session Fixtures
-----------------
+================
 
 These fixtures provide quick access to Brownie objects that are frequently used during testing. If you are unfamiliar with these objects, you may wish to read the documentation liested under "Core Functionality" in the table of contents.
 

--- a/docs/tests-pytest-intro.rst
+++ b/docs/tests-pytest-intro.rst
@@ -208,7 +208,7 @@ The sequence of events in the above example is:
 Handling Reverted Transactions
 ==============================
 
-When running tests, transactions that revert raise a :func:`VirtualMachineError <brownie.exceptions.VirtualMachineError>` exception. To write assertions around this you can use :func:`brownie.reverts <brownie.test.plugin.RevertContextManager>` as a context manager. It functions very similarly to `pytest.raises <https://docs.pytest.org/en/latest/assert.html#assertraises>`_.
+When running tests, transactions that revert raise a :func:`VirtualMachineError <brownie.exceptions.VirtualMachineError>` exception. To write assertions around this you can use :func:`brownie.reverts <brownie.test.plugin.RevertContextManager>` as a context manager. It functions very similarly to :func:`pytest.raises <pytest.raises>`.
 
 .. code-block:: python
     :linenos:

--- a/tests/project/compiler/test_main_compiler.py
+++ b/tests/project/compiler/test_main_compiler.py
@@ -11,7 +11,7 @@ def test_multiple_compilers(solc4source, vysource):
         {
             "solc4.sol": solc4source,
             "vyper.vy": vysource,
-            "solc6.sol": "pragma solidity 0.6.0; contract Foo {}",
+            "solc6.sol": "pragma solidity 0.6.2; contract Foo {}",
         }
     )
 

--- a/tests/project/compiler/test_solidity.py
+++ b/tests/project/compiler/test_solidity.py
@@ -27,7 +27,7 @@ def solc5json(solc5source):
 
 @pytest.fixture
 def solc6json(solc6source):
-    compiler.set_solc_version("0.6.0")
+    compiler.set_solc_version("0.6.2")
     input_json = compiler.generate_input_json({"path.sol": solc6source}, True, 200)
     yield compiler.compile_from_input_json(input_json)
 
@@ -134,7 +134,7 @@ def test_build_json_unlinked_libraries(solc4source, solc5source, solc6source):
     assert "__Bar__" in build_json["Foo"]["bytecode"]
     build_json = compiler.compile_and_format({"path.sol": solc5source}, solc_version="0.5.7")
     assert "__Bar__" in build_json["Foo"]["bytecode"]
-    build_json = compiler.compile_and_format({"path.sol": solc6source}, solc_version="0.6.0")
+    build_json = compiler.compile_and_format({"path.sol": solc6source}, solc_version="0.6.2")
     assert "__Bar__" in build_json["Foo"]["bytecode"]
 
 


### PR DESCRIPTION
### What I did
1. Add intersphinx to docs to allow pretty links to external documentation.
2. Fix a few formatting issues.
