### PR TITLE
v1.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ This changelog format is based on [Keep a Changelog](https://keepachangelog.com/
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/iamdefinitelyahuman/brownie)
+
+## [1.6.2](https://github.com/iamdefinitelyahuman/brownie/tree/v1.6.2) - 2020-02-05
+### Fixed
+- Retrieve config file from brownie/data when generating new project
+
 ## [1.6.1](https://github.com/iamdefinitelyahuman/brownie/tree/v1.6.1) - 2020-02-03
 ### Changed
 - Bump dependency versions, notably [web3.py](https://github.com/ethereum/web3.py) [v5.5.0](https://web3py.readthedocs.io/en/stable/releases.html#v5-5-0-2020-02-03) to support the new [ENS registry](https://medium.com/the-ethereum-name-service/ens-registry-migration-bug-fix-new-features-64379193a5a)

--- a/brownie/_cli/__main__.py
+++ b/brownie/_cli/__main__.py
@@ -10,7 +10,7 @@ from brownie.exceptions import ProjectNotFound
 from brownie.utils import color, notify
 from brownie.utils.docopt import docopt, levenshtein_norm
 
-__version__ = "1.6.1"
+__version__ = "1.6.2"
 
 __doc__ = """Usage:  brownie <command> [<args>...] [options <args>]
 

--- a/brownie/project/main.py
+++ b/brownie/project/main.py
@@ -15,7 +15,6 @@ from tqdm import tqdm
 from brownie._config import (
     BROWNIE_FOLDER,
     CONFIG,
-    _get_data_folder,
     _get_project_config_path,
     _load_project_compiler_config,
     _load_project_config,
@@ -358,7 +357,7 @@ def new(project_path_str: str = ".", ignore_subfolder: bool = False) -> str:
     _create_gitfiles(project_path)
     if not _get_project_config_path(project_path):
         shutil.copy(
-            _get_data_folder().joinpath("brownie-config.yaml"),
+            BROWNIE_FOLDER.joinpath("data/brownie-config.yaml"),
             project_path.joinpath("brownie-config.yaml"),
         )
     if not project_path.joinpath("ethpm-config.yaml").exists():
@@ -407,7 +406,7 @@ def from_brownie_mix(
     _create_folders(project_path)
     _create_gitfiles(project_path)
     shutil.copy(
-        _get_data_folder().joinpath("brownie-config.yaml"),
+        BROWNIE_FOLDER.joinpath("data/brownie-config.yaml"),
         project_path.joinpath("brownie-config.yaml"),
     )
     _add_to_sys_path(project_path)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,7 +37,7 @@ author = "Ben Hauser"
 # The short X.Y version
 version = ""
 # The full version, including alpha/beta/rc tags
-release = "v1.6.1"
+release = "v1.6.2"
 
 
 # -- General configuration ---------------------------------------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ psutil>=5.6.7,<6.0.0
 py>=1.5.0
 pyreadline==2.1;platform_system=='Windows'
 py-solc-ast>=1.1.0,<2.0.0
-py-solc-x>=0.7.1,<1.0.0
+py-solc-x>=0.7.2,<1.0.0
 pytest==5.3.5
 pytest-xdist==1.31.0
 pythx==1.4.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.6.1
+current_version = 1.6.2
 
 [bumpversion:file:setup.py]
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open("requirements.txt", "r") as f:
 setup(
     name="eth-brownie",
     packages=find_packages(),
-    version="1.6.1",  # don't change this manually, use bumpversion instead
+    version="1.6.2",  # don't change this manually, use bumpversion instead
     license="MIT",
     description="A Python framework for Ethereum smart contract deployment, testing and interaction.",  # noqa: E501
     long_description=long_description,

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ deps =
 commands =
     py{36,37,38}: python -m pytest tests/ --cov-append
     evmtest: python -m pytest tests/ --target evm --cov-append
-    mixtest: python -m pytest tests/ --target mixes --cov-append
+    mixtest: python -m pytest tests/ --target mixes --cov-append -n 0
     plugintest: python -m pytest tests/ --target plugin --cov-append -n 0
 
 [testenv:lint]


### PR DESCRIPTION
- Bugfix: Retrieve config file from `brownie/data` when generating new project
- bump `solcx` version to 0.7.2
- update changelog, bump version