### PR TITLE
bugfix: REVERT outside of function when generating revert map

### DIFF
--- a/brownie/project/build.py
+++ b/brownie/project/build.py
@@ -72,7 +72,7 @@ class Build:
             revert = (
                 data["path"],
                 tuple(data["offset"]),
-                data["fn"],
+                data.get("fn", "<None>"),
                 data.get("dev", msg),
                 self._sources,
             )


### PR DESCRIPTION
### What I did
Fix a compilation bug when a `REVERT` or `INVALID` occurs outside of a function.
