### PR TITLE
Stateful test flag, docs, bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This changelog format is based on [Keep a Changelog](https://keepachangelog.com/
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/iamdefinitelyahuman/brownie)
+### Fixed
+- Warn instead of raising when an import spec cannot be found
 
 ## [1.6.2](https://github.com/iamdefinitelyahuman/brownie/tree/v1.6.2) - 2020-02-05
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This changelog format is based on [Keep a Changelog](https://keepachangelog.com/
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/iamdefinitelyahuman/brownie)
+### Added
+- `--stateful` flag to only run or skip stateful test cases
+
 ### Fixed
 - Warn instead of raising when an import spec cannot be found
 

--- a/brownie/_cli/test.py
+++ b/brownie/_cli/test.py
@@ -10,21 +10,22 @@ from brownie.utils.docopt import docopt
 __doc__ = f"""Usage: brownie test [<path>] [options]
 
 Arguments:
-  [<path>]              Path to the test(s) to run
+  [<path>]                 Path to the test(s) to run
 
 Brownie Options:
-  --update -U           Only run tests where changes have occurred
-  --coverage -C         Evaluate contract test coverage
-  --revert-tb -R        Show detailed traceback on unhandled transaction reverts
-  --gas -G              Display gas profile for function calls
-  --network [name]      Use a specific network (default {CONFIG['network']['default']})
+  --update -U              Only run tests where changes have occurred
+  --coverage -C            Evaluate contract test coverage
+  --stateful [true,false]  Only run stateful tests, or skip them
+  --revert-tb -R           Show detailed traceback on unhandled transaction reverts
+  --gas -G                 Display gas profile for function calls
+  --network [name]         Use a specific network (default {CONFIG['network']['default']})
 
 Pytest Options:
-  -n [numprocesses]     Number of workers to use for xdist distributed testing,
-                        set to 'auto' for automatic detection of number of CPUs
-  --durations [num]     show slowest setup/test durations (num=0 for all)
-  --exitfirst -x        Exit instantly on first error or failed test
-  --verbose -v          Increase verbosity
+  -n [numprocesses]        Number of workers to use for xdist distributed testing,
+                           set to 'auto' for automatic detection of number of CPUs
+  --durations [num]        show slowest setup/test durations (num=0 for all)
+  --exitfirst -x           Exit instantly on first error or failed test
+  --verbose -v             Increase verbosity
 
 Help Options:
   --fixtures            Show a list of available fixtures

--- a/brownie/project/scripts.py
+++ b/brownie/project/scripts.py
@@ -3,6 +3,7 @@
 import ast
 import importlib
 import sys
+import warnings
 from hashlib import sha1
 from pathlib import Path
 from types import ModuleType
@@ -114,8 +115,13 @@ def _get_ast_hash(path: str) -> str:
             name = obj.module  # type: ignore
         try:
             origin = importlib.util.find_spec(name).origin
-        except Exception as e:
-            raise type(e)(f"in {path} - {e}") from None
+        except Exception:
+            warnings.warn(
+                f"{Path(path).name}, unable to determine import spec for '{name}',"
+                " the --update flag may not work correctly with this test file",
+                ImportWarning,
+            )
+            continue
         if base_path in origin:
             with open(origin) as fp:
                 ast_list.append(ast.parse(fp.read(), origin))

--- a/brownie/test/managers/runner.py
+++ b/brownie/test/managers/runner.py
@@ -69,6 +69,7 @@ class PytestBrownieRunner(PytestBrownieBase):
         _make_fixture_execute_first(metafunc, "fn_isolation", "function")
 
     def pytest_collection_modifyitems(self, items):
+        stateful = self.config.getoption("--stateful")
         self._make_nodemap([i.nodeid for i in items])
 
         # determine which modules are properly isolated
@@ -76,6 +77,11 @@ class PytestBrownieRunner(PytestBrownieBase):
         for i in items:
             if "skip_coverage" in i.fixturenames and ARGV["coverage"]:
                 i.add_marker("skip")
+            if stateful is not None:
+                if stateful == "true" and "state_machine" not in i.fixturenames:
+                    i.add_marker("skip")
+                elif stateful == "false" and "state_machine" in i.fixturenames:
+                    i.add_marker("skip")
             path = self._path(i.parent.fspath)
             if "module_isolation" not in i.fixturenames:
                 tests[path] = None

--- a/brownie/test/plugin.py
+++ b/brownie/test/plugin.py
@@ -22,6 +22,12 @@ def pytest_addoption(parser):
             "--revert-tb", "-R", action="store_true", help="Show detailed traceback on tx reverts"
         )
         parser.addoption(
+            "--stateful",
+            choices=["true", "false"],
+            default=None,
+            help="Only run or skip stateful tests (default: run all tests)",
+        )
+        parser.addoption(
             "--network",
             "-N",
             default=False,

--- a/docs/api-convert.rst
+++ b/docs/api-convert.rst
@@ -96,7 +96,7 @@ Fixed
 
 .. py:class:: brownie.convert.datatypes.Fixed(value)
 
-    `Decimal <https://docs.python.org/3.8/library/decimal.html#decimal.Decimal>`_ subclass that allows comparisons, addition and subtraction against strings, integers and :func:`Wei <brownie.convert.datatypes.Wei>`.
+    :py:class:`decimal.Decimal <decimal.Decimal>` subclass that allows comparisons, addition and subtraction against strings, integers and :func:`Wei <brownie.convert.datatypes.Wei>`.
 
     ``Fixed`` is used for inputs and outputs to Vyper contracts that use the `decimal type <https://vyper.readthedocs.io/en/latest/types.html#decimals>`_.
 

--- a/docs/core-contracts.rst
+++ b/docs/core-contracts.rst
@@ -126,7 +126,7 @@ If you wish to call the contract method without a transaction, use the :func:`Co
 Transaction Parameters
 **********************
 
-When executing a transaction to a contract, you can optionally include an dictionary of transaction parameters as the final input. It may contain the following values:
+When executing a transaction to a contract, you can optionally include a :py:class:`dict <dict>` of transaction parameters as the final input. It may contain the following values:
 
     * ``from``: the :func:`Account <brownie.network.account.Account>` that the transaction it sent from. If not given, the transaction is sent from the account that deployed the contract.
     * ``gas_limit``: The amount of gas provided for transaction execution, in wei. If not given, the gas limit is determined using ``web3.eth.estimateGas``.

--- a/docs/core-types.rst
+++ b/docs/core-types.rst
@@ -9,7 +9,7 @@ Brownie uses custom data types to simplify working with common represented value
 Wei
 ===
 
-The :func:`Wei <brownie.convert.datatypes.Wei>` class is used when a value is meant to represent an amount of Ether. It is a subclass of ``int`` capable of converting strings, scientific notation and hex strings into wei denominated integers:
+The :func:`Wei <brownie.convert.datatypes.Wei>` class is used when a value is meant to represent an amount of Ether. It is a subclass of :py:class:`int <int>` capable of converting strings, scientific notation and hex strings into wei denominated integers:
 
 .. code-block:: python
 
@@ -43,7 +43,7 @@ Whenever a Brownie method takes an input referring to an amount of ether, the gi
 Fixed
 =====
 
-The :func:`Fixed <brownie.convert.datatypes.Fixed>` class is used to handle Vyper `decimal values <https://vyper.readthedocs.io/en/latest/types.html#decimals>`_. It is a subclass of `Decimal <https://docs.python.org/3.8/library/decimal.html#decimal.Decimal>`_ that allows comparisons, addition and subtraction against strings, integers and :func:`Wei <brownie.convert.datatypes.Wei>`.
+The :func:`Fixed <brownie.convert.datatypes.Fixed>` class is used to handle Vyper `decimal values <https://vyper.readthedocs.io/en/latest/types.html#decimals>`_. It is a subclass of :py:class:`decimal.Decimal <decimal.Decimal>` that allows comparisons, addition and subtraction against strings, integers and :func:`Wei <brownie.convert.datatypes.Wei>`.
 
 .. code-block:: python
 

--- a/docs/tests-hypothesis-property.rst
+++ b/docs/tests-hypothesis-property.rst
@@ -177,7 +177,7 @@ Decimal
 
     `Base strategy:` :func:`hypothesis.strategies.decimals <hypothesis.strategies.decimals>`
 
-``decimal`` strategies yield ``decimal.Decimal`` instances.
+``decimal`` strategies yield :py:class:`decimal.Decimal <decimal.Decimal>` instances.
 
 Optional keyword arguments:
 

--- a/tests/test/plugin/test_stateful_flag.py
+++ b/tests/test/plugin/test_stateful_flag.py
@@ -1,0 +1,27 @@
+#!/usr/bin/python3
+
+test_source = """
+def test_rpc(state_machine):
+    assert True
+
+def test_web3():
+    assert False
+    """
+
+
+def test_stateful_flag(plugintester):
+    result = plugintester.runpytest()
+    result.assert_outcomes(passed=1, failed=1)
+    result = plugintester.runpytest("--stateful=false")
+    result.assert_outcomes(skipped=1, failed=1)
+    result = plugintester.runpytest("--stateful=true")
+    result.assert_outcomes(skipped=1, passed=1)
+
+
+def test_stateful_flag_xdist(isolatedtester):
+    result = isolatedtester.runpytest("-n 2")
+    result.assert_outcomes(passed=1, failed=1)
+    result = isolatedtester.runpytest("-n 2", "--stateful=false")
+    result.assert_outcomes(skipped=1, failed=1)
+    result = isolatedtester.runpytest("-n 2", "--stateful=true")
+    result.assert_outcomes(skipped=1, passed=1)


### PR DESCRIPTION
### What I did
1. Add `--stateful` flag when running tests, to only run or exclude tests using the `state_machine` fixture
2. Warn instead of raising when an import spec can't be found during test hashing
3. Link to `NFToken` in docs as a real-world example of stateful testing

### How to verify it
Run tests. I added new cases.

### Checklist
- [x] I have confirmed that my PR passes all linting checks
- [x] I have included test cases
- [x] I have updated the documentation
- [x] I have added an entry to the changelog
