### PR TITLE
Eip170 checks, v1.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,18 @@ This changelog format is based on [Keep a Changelog](https://keepachangelog.com/
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/iamdefinitelyahuman/brownie)
+
+## [1.6.3](https://github.com/iamdefinitelyahuman/brownie/tree/v1.6.3) - 2020-02-09
 ### Added
 - `--stateful` flag to only run or skip stateful test cases
+- [EIP-170](https://github.com/ethereum/EIPs/issues/170) size limits: warn on compile, give useful error message on failed deployment
+
+### Changed
+- unexpanded transaction trace is available for deployment transactions
 
 ### Fixed
 - Warn instead of raising when an import spec cannot be found
+- Handle `REVERT` outside of function when generating revert map
 
 ## [1.6.2](https://github.com/iamdefinitelyahuman/brownie/tree/v1.6.2) - 2020-02-05
 ### Fixed

--- a/brownie/_cli/__main__.py
+++ b/brownie/_cli/__main__.py
@@ -10,7 +10,7 @@ from brownie.exceptions import ProjectNotFound
 from brownie.utils import color, notify
 from brownie.utils.docopt import docopt, levenshtein_norm
 
-__version__ = "1.6.2"
+__version__ = "1.6.3"
 
 __doc__ = """Usage:  brownie <command> [<args>...] [options <args>]
 

--- a/brownie/project/compiler/__init__.py
+++ b/brownie/project/compiler/__init__.py
@@ -5,6 +5,7 @@ from copy import deepcopy
 from pathlib import Path
 from typing import Dict, Optional, Union
 
+from eth_utils import remove_0x_prefix
 from semantic_version import Version
 
 from brownie.exceptions import UnsupportedLanguage
@@ -15,6 +16,7 @@ from brownie.project.compiler.solidity import (  # NOQA: F401
     install_solc,
     set_solc_version,
 )
+from brownie.utils import notify
 
 from . import solidity, vyper
 
@@ -279,6 +281,12 @@ def generate_build_json(
                 "sourcePath": path_str,
             }
         )
+        size = len(remove_0x_prefix(output_evm["deployedBytecode"]["object"])) / 2  # type: ignore
+        if size > 24577:
+            notify(
+                "WARNING",
+                f"deployed size of {contract_name} is {size} bytes, exceeds EIP-170 limit of 24577",
+            )
 
     if not silent:
         print("")

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,7 +37,7 @@ author = "Ben Hauser"
 # The short X.Y version
 version = ""
 # The full version, including alpha/beta/rc tags
-release = "v1.6.2"
+release = "v1.6.3"
 
 
 # -- General configuration ---------------------------------------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.6.2
+current_version = 1.6.3
 
 [bumpversion:file:setup.py]
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open("requirements.txt", "r") as f:
 setup(
     name="eth-brownie",
     packages=find_packages(),
-    version="1.6.2",  # don't change this manually, use bumpversion instead
+    version="1.6.3",  # don't change this manually, use bumpversion instead
     license="MIT",
     description="A Python framework for Ethereum smart contract deployment, testing and interaction.",  # noqa: E501
     long_description=long_description,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -96,7 +96,16 @@ def pytest_sessionstart():
     monkeypatch_session = MonkeyPatch()
     monkeypatch_session.setattr(
         "solcx.get_available_solc_versions",
-        lambda: ["v0.6.2", "v0.5.15", "v0.5.8", "v0.5.7", "v0.4.25", "v0.4.24", "v0.4.22"],
+        lambda: [
+            "v0.6.2",
+            "v0.5.15",
+            "v0.5.8",
+            "v0.5.7",
+            "v0.5.0",
+            "v0.4.25",
+            "v0.4.24",
+            "v0.4.22",
+        ],
     )
 
 

--- a/tests/network/transaction/test_revert_msg.py
+++ b/tests/network/transaction/test_revert_msg.py
@@ -3,6 +3,7 @@
 import pytest
 
 from brownie.exceptions import VirtualMachineError
+from brownie.project import compile_source
 
 
 def test_revert_msg_via_jump(ext_tester, console_mode):
@@ -76,3 +77,9 @@ def test_vyper_revert_reasons(vypertester, console_mode):
     assert tx.revert_msg == "Modulo by zero"
     tx = vypertester.overflow(0, 0, {"value": 31337})
     assert tx.revert_msg == "Cannot send ether to nonpayable function"
+
+
+def test_deployment_size_limit(accounts, console_mode):
+    code = f"@public\ndef baz():\n    assert msg.sender != ZERO_ADDRESS, '{'blah'*10000}'"
+    tx = compile_source(code).Vyper.deploy({"from": accounts[0]})
+    assert tx.revert_msg == "exceeds EIP-170 size limit"

--- a/tests/network/transaction/test_trace.py
+++ b/tests/network/transaction/test_trace.py
@@ -158,8 +158,9 @@ def test_call_trace(console_mode, tester):
 
 
 def test_trace_deploy(tester):
-    """trace is not calculated for deploying contracts"""
-    assert not tester.tx.trace
+    """trace is calculated for deploying contracts but not expanded"""
+    assert tester.tx.trace
+    assert "fn" not in tester.tx.trace[0]
 
 
 def test_trace_transfer(accounts):

--- a/tests/network/transaction/test_verbosity.py
+++ b/tests/network/transaction/test_verbosity.py
@@ -50,9 +50,11 @@ def test_error(tx, reverted_tx, capfd):
 
 def test_deploy_reverts(BrownieTester, accounts, console_mode):
     tx = BrownieTester.deploy(True, {"from": accounts[0]}).tx
-    tx.traceback()
+    with pytest.raises(NotImplementedError):
+        tx.traceback()
     with pytest.raises(NotImplementedError):
         tx.call_trace()
+
     revertingtx = BrownieTester.deploy(False, {"from": accounts[0]})
     with pytest.raises(NotImplementedError):
         revertingtx.call_trace()

--- a/tests/project/compiler/test_solidity.py
+++ b/tests/project/compiler/test_solidity.py
@@ -222,3 +222,13 @@ def test_get_abi():
             "type": "function",
         }
     ]
+
+
+def test_size_limit(capfd):
+    code = f"""
+pragma solidity 0.6.2;
+contract Foo {{ function foo() external returns (bool) {{
+    require(msg.sender != address(0), "{"blah"*10000}"); }}
+}}"""
+    compiler.compile_and_format({"foo.sol": code})
+    assert "exceeds EIP-170 limit of 24577" in capfd.readouterr()[0]

--- a/tests/project/compiler/test_vyper.py
+++ b/tests/project/compiler/test_vyper.py
@@ -83,3 +83,9 @@ def test_get_abi():
             "gas": 351,
         }
     ]
+
+
+def test_size_limit(capfd):
+    code = f"@public\ndef baz():\n    assert msg.sender != ZERO_ADDRESS, '{'blah'*10000}'"
+    compiler.compile_and_format({"foo.vy": code})
+    assert "exceeds EIP-170 limit of 24577" in capfd.readouterr()[0]


### PR DESCRIPTION
### What I did
1. Add checks for contract size exceeding [EIP170](https://github.com/ethereum/EIPs/issues/170) limit. At compile time a warning is raised, at deployment a more meaningful revert string is given.
2. Allow access to the unexpanded trace on deployment transactions.
3. Bump version to `1.6.3`

### How to verify it
Run the tests.

### Checklist
- [x] I have confirmed that my PR passes all linting checks
- [x] I have included test cases
- [x] I have added an entry to the changelog
