### PR TITLE
pytest ContractContainer imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This changelog format is based on [Keep a Changelog](https://keepachangelog.com/
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/iamdefinitelyahuman/brownie)
+### Fixed
+- allow import of project `ContractContainer` instances from `brownie` when running tests
 
 ## [1.6.3](https://github.com/iamdefinitelyahuman/brownie/tree/v1.6.3) - 2020-02-09
 ### Added

--- a/brownie/project/scripts.py
+++ b/brownie/project/scripts.py
@@ -2,7 +2,6 @@
 
 import ast
 import importlib
-import sys
 import warnings
 from hashlib import sha1
 from pathlib import Path
@@ -44,11 +43,7 @@ def run(
     script, project = _get_path(script_path)
 
     # temporarily add project objects to the main namespace, so the script can import them
-    brownie: Any = sys.modules["brownie"]
-    brownie_dict = brownie.__dict__.copy()
-    brownie_all = brownie.__all__.copy()
-    brownie.__dict__.update(project)
-    brownie.__all__.extend(project.__all__)
+    project._add_to_main_namespace()
 
     try:
         script = script.absolute().relative_to(project._path)
@@ -64,9 +59,7 @@ def run(
         return getattr(module, method_name)(*args, **kwargs)
     finally:
         # cleanup namespace
-        brownie.__dict__.clear()
-        brownie.__dict__.update(brownie_dict)
-        brownie.__all__ = brownie_all
+        project._remove_from_main_namespace()
 
 
 def _get_path(path_str: str) -> Tuple[Path, Project]:

--- a/brownie/test/plugin.py
+++ b/brownie/test/plugin.py
@@ -41,6 +41,7 @@ def pytest_configure(config):
 
         active_project = project.load()
         active_project.load_config()
+        active_project._add_to_main_namespace()
 
         if config.getoption("numprocesses"):
             Plugin = PytestBrownieMaster

--- a/tests/test/plugin/test_session_fixtures.py
+++ b/tests/test/plugin/test_session_fixtures.py
@@ -20,8 +20,9 @@ def test_web3(web3):
     """,
     """
 from brownie.network.contract import ContractContainer
+from brownie import EVMTester
 
-def test_contract_container(BrownieTester, EVMTester):
+def test_contract_container(BrownieTester):
     assert type(BrownieTester) is ContractContainer
     assert type(EVMTester) is ContractContainer
     """,


### PR DESCRIPTION
### What I did
Allow import of  `ContractContainer` instances from main `brownie` package when running tests. This behavior is documented, but for some reason was never actually implemented :fearful: 

### How I did it
Move namespace black magic from `project.scripts.run` to class methods in `project.main.Project`

### How to verify it
Run the tests.

### Checklist
- [x] I have confirmed that my PR passes all linting checks
- [x] I have included test cases
- [x] I have added an entry to the changelog
