### PR TITLE
Stateful test progress spinner

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,5 @@
 ### What I did
+
 Related issue: #
 
 ### How I did it
@@ -6,8 +7,6 @@ Related issue: #
 ### How to verify it
 
 ### Checklist
-
-_Depending on the scope of this PR, some or all items on this list may not be necessary._
 
 - [ ] I have confirmed that my PR passes all linting checks
 - [ ] I have included test cases

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ Brownie is a Python-based development and testing framework for smart contracts 
 ## Features
 
 * Full support for [Solidity](https://github.com/ethereum/solidity) (`>=0.4.22`) and [Vyper](https://github.com/vyperlang/vyper) (`0.1.0-b16`)
-* Contract testing via [pytest](https://github.com/pytest-dev/pytest), including trace-based coverage evaluation
+* Contract testing via [`pytest`](https://github.com/pytest-dev/pytest), including trace-based coverage evaluation
+* Property-based and stateful testing via [`hypothesis`](https://github.com/HypothesisWorks/hypothesis/tree/master/hypothesis-python)
 * Powerful debugging tools, including python-style tracebacks and custom error strings
 * Built-in console for quick project interaction
 * Support for [ethPM](https://www.ethpm.com) packages
@@ -18,17 +19,17 @@ Brownie is a Python-based development and testing framework for smart contracts 
 * [pip](https://pypi.org/project/pip/)
 * [python3](https://www.python.org/downloads/release/python-368/) version 3.6 or greater, python3-dev
 
-As Brownie relies on [py-solc-x](https://github.com/iamdefinitelyahuman/py-solc-x), you do not need solc installed locally but you must install all required [solc dependencies](https://solidity.readthedocs.io/en/latest/installing-solidity.html#binary-packages).
+As Brownie relies on [`py-solc-x`](https://github.com/iamdefinitelyahuman/py-solc-x), you do not need solc installed locally but you must install all required [solc dependencies](https://solidity.readthedocs.io/en/latest/installing-solidity.html#binary-packages).
 
 ## Installation
 
-You can install the latest release via ``pip``:
+You can install the latest release via [`pip`](https://pypi.org/project/pip/):
 
 ```bash
 pip install eth-brownie
 ```
 
-Or clone the repository and use ``setuptools`` for the most up-to-date version:
+Or clone the repository and use [`setuptools`](https://github.com/pypa/setuptools) for the most up-to-date version:
 
 ```bash
 python setup.py install
@@ -42,7 +43,7 @@ To set up the default folder and file structure for Brownie use:
 brownie init
 ```
 
-Next, type ``brownie --help`` for basic usage information.
+Next, type `brownie --help` for basic usage information.
 
 ## Documentation and Support
 
@@ -58,11 +59,11 @@ To run the tests, first install the developer dependencies:
 pip install -r requirements-dev.txt
 ```
 
-Then use ``tox`` to run the complete suite against the full set of build targets, or ``pytest`` to run tests against a specific version of Python. If you are using ``pytest`` you must include the ``-p no:pytest-brownie`` flag to prevent it from loading the Brownie plugin.
+Then use [`tox`](https://github.com/tox-dev/tox) to run the complete suite against the full set of build targets, or [`pytest`](https://github.com/pytest-dev/pytest) to run tests against a specific version of Python. If you are using [`pytest`](https://github.com/pytest-dev/pytest) you must include the `-p no:pytest-brownie` flag to prevent it from loading the Brownie plugin.
 
 ### Using Docker
 
-You can use a sandbox container provided in the `docker-compose.yml` file for testing inside a Docker environment.
+You can use a sandbox container provided in the [`docker-compose.yml`](docker-compose.yml) file for testing inside a Docker environment.
 
 This container provides everything you need to test using a Python 3.6 interpreter.
 

--- a/brownie/test/fixtures.py
+++ b/brownie/test/fixtures.py
@@ -91,7 +91,7 @@ class PytestBrownieFixtures:
         # implemented in pytest_collection_modifyitems
         pass
 
-    @pytest.fixture(scope="session")
+    @pytest.fixture
     def state_machine(self):
         """Yields a rule-based state machine factory method."""
 

--- a/brownie/test/stateful.py
+++ b/brownie/test/stateful.py
@@ -1,5 +1,7 @@
 #!/usr/bin/python3
 
+import sys
+from collections import deque
 from inspect import getmembers
 from types import FunctionType
 from typing import Any, Optional
@@ -9,15 +11,26 @@ from hypothesis import stateful as sf
 from hypothesis.strategies import SearchStrategy
 
 import brownie
+from brownie.utils import color
 
 __tracebackhide__ = True
 sf.__tracebackhide__ = True
+
+marker = deque("-/|\\-/|\\")
 
 
 class _BrownieStateMachine:
     def __init__(self) -> None:
         brownie.rpc.revert()
         sf.RuleBasedStateMachine.__init__(self)
+
+        capman = getattr(self, "_capman", None)
+        if capman:
+            with capman.global_and_fixture_disabled():
+                sys.stdout.write(f"{color('yellow')}{marker[0]}\033[1D")
+                sys.stdout.flush()
+            marker.rotate(1)
+
         if hasattr(self, "setup"):
             self.setup()  # type: ignore
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,6 +17,7 @@ Features
 
 * Full support for `Solidity <https://github.com/ethereum/solidity>`_ and `Vyper <https://github.com/vyperlang/vyper>`_
 * Contract testing via `pytest <https://github.com/pytest-dev/pytest>`_, including trace-based coverage evaluation
+* Property-based and stateful testing via `hypothesis <https://github.com/HypothesisWorks/hypothesis/tree/master/hypothesis-python>`_
 * Powerful debugging tools, including python-style tracebacks and custom error strings
 * Built-in console for quick project interaction
 * Support for `ethPM <https://www.ethpm.com>`_ packages

--- a/docs/tests-hypothesis-stateful.rst
+++ b/docs/tests-hypothesis-stateful.rst
@@ -26,7 +26,7 @@ A state machine is a class used within stateful testing. It defines the initial 
 
 .. note::
 
-    Unlike regular Hypothesis state machines, Brownie state machines should not subclass ``RuleBasedStateMachine``.
+    Unlike regular Hypothesis state machines, Brownie state machines should not subclass :py:class:`RuleBasedStateMachine <hypothesis.stateful.RuleBasedStateMachine>`.
 
 Rules
 -----
@@ -65,7 +65,7 @@ Any state machine method named ``initialize`` or beginning with ``initialize_`` 
 Strategies
 ----------
 
-A state machine should contain one or more :ref:`hypothesis-strategies`, in order to provide data to it's rules.
+A state machine should contain one or more :ref:`strategies <hypothesis-strategies>`, in order to provide data to it's rules.
 
 Strategies must be defined at the class level, typically before the first function. They can be given any name.
 
@@ -285,7 +285,27 @@ On line 12, rather than subtracting ``value``, the balance is being `set` to ``v
 More Examples
 -------------
 
-Here are some links to repositories that make use of stateful testing. If you have a project that you would like included here, feel free to `edit this document <https://github.com/iamdefinitelyahuman/brownie/edit/master/docs/tests-hypothesis-stateful.rst>`_ and open a pull request, or let us know about it on Gitter.
+Here are some links to repositories that make use of stateful testing. If you have a project that you would like included here, feel free to `edit this document <https://github.com/iamdefinitelyahuman/brownie/edit/master/docs/tests-hypothesis-stateful.rst>`_ and open a pull request, or let us know about it on `Gitter <https://gitter.im/eth-brownie/community>`_.
 
     * `iamdefinitelyahuman/NFToken <https://github.com/iamdefinitelyahuman/nftoken/tree/master/tests/stateful>`_: A non-fungible implementation of the ERC20 standard.
 
+Running Stateful Tests
+======================
+
+By default, stateful tests are included when you run your test suite. There is no special action required to invoke them.
+
+You can choose to exclude stateful tests, or to *only* run stateful tests, with the ``--stateful`` flag. This can be useful to split the test suite when setting up `continuous integration <https://github.com/brownie-mix/travis-mix>`_.
+
+To only run stateful tests:
+
+::
+
+    $ brownie test --stateful true
+
+To skip stateful tests:
+
+::
+
+    $ brownie test --stateful false
+
+When a stateful test is active the console shows a spinner that rotates each time a run of the test has finished. If the color changes from yellow to red, it means the test has failed and hypothesis is now searching for the shortest path to the failure.


### PR DESCRIPTION
### What I did
Add a spinner to show progress on stateful tests when running pytest. Initially the spinner is yellow, once the test fails and is being reduced it changes to red.

Closes #358

### How I did it
Taking further advantage of the meta-class magic of `_BrownieStateMachine`.

### How to verify it
Run the tests.

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [x] I have updated the documentation
- [ ] I have added an entry to the changelog
