### PR TITLE
Mythx updates

### DIFF
--- a/docs/tests-security-analysis.rst
+++ b/docs/tests-security-analysis.rst
@@ -3,13 +3,11 @@
 .. raw:: html
 
     <style>
-    .green {background:#228822; color: #ffffff; padding: 2px 5px;}
     .yellow {background:#ff9933; color: #ffffff; padding: 2px 5px;}
     .orange {background:#ff3300; color: #ffffff; padding: 2px 5px;}
     .red {background:#882222; color: #ffffff; padding: 2px 5px;}
     </style>
 
-.. role:: green
 .. role:: yellow
 .. role:: orange
 .. role:: red
@@ -27,7 +25,22 @@ MythX is a smart contract security service that scans your project for vulnerabi
 
 MythX offers both free and paid services. To learn more about how it works you may wish to read `MythX Pro Security Analysis Explained <https://blog.mythx.io/features/mythx-full-mode-security-analysis-explained/#more-37>`_ by Bernhard Mueller.
 
+Authentication
+==============
 
+Before you can submit your contracts for analysis you must `sign up <https://dashboard.mythx.io/registration>`_ for a MythX account. Next, login to your account and obtain a JWT token so you can authenticate to the API.
+
+The preferred way to pass your JWT token is via the ``MYTHX_API_KEY`` environment variable. You can set it with the following command:
+
+::
+
+    $ export MYTHX_API_KEY=YourToken
+
+If this is not possible, you may also pass it via the ``--api-key`` commandline option:
+
+::
+
+    $ brownie analyze --api-key=<string>
 
 Scanning for Vulnerabilities
 ============================
@@ -49,42 +62,6 @@ To perform a full scan:
 Note that a full scan requires authentication and takes approximately half an hour to complete.
 
 If you include the ``--async`` flag Brownie will submit the job, output the pending ID and exit. You can view the finished report later through the MythX dashboard.
-
-Authentication
-==============
-
-In order to perform a full scan or track your analysis history, you are required to authenticate. This can be done using either a JWT token obtained from the `MythX dashboard <https://dashboard.mythx.io/>`_, or with your username and password.
-
-With a JWT Token
-----------------
-
-The preferred way to pass your JWT token is via the ``MYTHX_ACCESS_TOKEN`` environment variable. You can set it with the following command:
-
-::
-
-    $ export MYTHX_ACCESS_TOKEN=YourToken
-
-If this is not possible, you may also pass it via the ``--access-token`` commandline option:
-
-::
-
-    $ brownie analyze --access-token=<string>
-
-With your Username and Password
--------------------------------
-
-The preferred way to pass your username and password is via the ``MYTHX_ETH_ADDRESS`` and ``MYTHX_PASSWORD`` environment variables. Set them with the following commands:
-
-::
-
-    $ export MYTHX_ETH_ADDRESS=YourAddress
-    $ export MYTHX_PASSWORD=YourPassword
-
-If this is not possible, you may also pass them via the commandline:
-
-::
-
-    $ brownie analyze --eth-address=<string> --password=<string>
 
 Viewing Analysis Results
 ========================

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ py-solc-ast>=1.1.0,<2.0.0
 py-solc-x>=0.7.2,<1.0.0
 pytest==5.3.5
 pytest-xdist==1.31.0
-pythx==1.4.1
+pythx==1.5.3
 pyyaml>=5.3.0,<6.0.0
 requests>=2.22.0,<3.0.0
 semantic-version>=2.8.4,<3.0.0

--- a/tests/cli/test_cli_main.py
+++ b/tests/cli/test_cli_main.py
@@ -85,23 +85,6 @@ def test_cli_compile(cli_tester, testproject):
     assert cli_tester.mock_subroutines.call_count == 2
 
 
-def test_cli_analyze(cli_tester, testproject):
-    cli_tester.monkeypatch.setattr(
-        "brownie._cli.analyze.send_to_mythx", lambda job_data, client, authenticated: ["UUID_1"]
-    )
-    cli_tester.monkeypatch.setattr("pythx.Client.analysis_ready", lambda client, uuid: True)
-    cli_tester.monkeypatch.setattr(
-        "brownie._cli.analyze.update_report",
-        lambda client, uuid, hl_report, stdout_report, name: stdout_report.setdefault(
-            "x", {}
-        ).setdefault("HIGH", 1),
-    )
-    cli_tester.run_and_test_parameters("analyze", parameters=None)
-
-    assert cli_tester.mock_subroutines.called is False
-    assert cli_tester.mock_subroutines.call_count == 0
-
-
 def test_cli_analyze_with_mocked_project(cli_tester, testproject):
     cli_tester.monkeypatch.setattr("brownie.project.load", cli_tester.mock_subroutines)
     cli_tester.run_and_test_parameters("analyze")


### PR DESCRIPTION
### What I did
1. Bump `pythx` version to 1.5.3
2. Update `brownie analyze` based on MythX updates
   1. Remove deprecated username/password options
   2. Require authentication
   3. Change environment variable to `MYTHX_API_KEY` and cli flag to `--api-key`

### How to verify it
Run the tests.

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [x] I have included test cases
- [x] I have updated the documentation
- [ ] I have added an entry to the changelog
