### PR TITLE
V1.6.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/iamdefinitelyahuman/brownie)
 
+## [1.6.8](https://github.com/iamdefinitelyahuman/brownie/tree/v1.6.8) - 2020-03-30
+
+### Changed
+- Use Vyper [v0.1.0-beta17](https://github.com/vyperlang/vyper/releases/tag/v0.1.0-beta.17)
+
+### Fixed
+- Bug when determining dependencies of a `Contract` object
+
 ## [1.6.7](https://github.com/iamdefinitelyahuman/brownie/tree/v1.6.7) - 2020-03-09
 
 ### Fixed
-- INVALID instructions with no related ast node (assembly)
+- `INVALID` instructions with no related ast node (assembly)
 - Missing f-strings in compiler output
 
 ## [1.6.6](https://github.com/iamdefinitelyahuman/brownie/tree/v1.6.6) - 2020-03-03

--- a/brownie/_cli/__main__.py
+++ b/brownie/_cli/__main__.py
@@ -10,7 +10,7 @@ from brownie.exceptions import ProjectNotFound
 from brownie.utils import color, notify
 from brownie.utils.docopt import docopt, levenshtein_norm
 
-__version__ = "1.6.7"
+__version__ = "1.6.8"
 
 __doc__ = """Usage:  brownie <command> [<args>...] [options <args>]
 

--- a/brownie/network/state.py
+++ b/brownie/network/state.py
@@ -98,7 +98,7 @@ def _find_contract(address: Any) -> Any:
 def _get_current_dependencies() -> List:
     dependencies = set(v._name for v in _contract_map.values())
     for contract in _contract_map.values():
-        dependencies.update(contract._build["dependencies"])
+        dependencies.update(contract._build.get("dependencies", []))
     return sorted(dependencies)
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,7 +37,7 @@ author = "Ben Hauser"
 # The short X.Y version
 version = ""
 # The full version, including alpha/beta/rc tags
-release = "v1.6.7"
+release = "v1.6.8"
 
 
 # -- General configuration ---------------------------------------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,13 +9,13 @@ psutil>=5.7.0,<6.0.0
 py>=1.5.0
 pyreadline==2.1;platform_system=='Windows'
 py-solc-ast>=1.2.1,<2.0.0
-py-solc-x>=0.8.0,<1.0.0
-pytest==5.3.5
+py-solc-x>=0.8.1,<1.0.0
+pytest==5.4.1
 pytest-xdist==1.31.0
 pythx==1.5.5
 pyyaml>=5.3.0,<6.0.0
 requests>=2.23.0,<3.0.0
 semantic-version>=2.8.4,<3.0.0
 tqdm==4.43.0
-vyper==0.1.0b16
+vyper==0.1.0b17
 web3==5.5.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.6.7
+current_version = 1.6.8
 
 [bumpversion:file:setup.py]
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open("requirements.txt", "r") as f:
 setup(
     name="eth-brownie",
     packages=find_packages(),
-    version="1.6.7",  # don't change this manually, use bumpversion instead
+    version="1.6.8",  # don't change this manually, use bumpversion instead
     license="MIT",
     description="A Python framework for Ethereum smart contract deployment, testing and interaction.",  # noqa: E501
     long_description=long_description,

--- a/tests/project/compiler/test_vyper.py
+++ b/tests/project/compiler/test_vyper.py
@@ -75,7 +75,7 @@ def test_get_abi():
     assert abi["Foo"] == [
         {
             "name": "baz",
-            "outputs": [{"type": "bool", "name": "out"}],
+            "outputs": [{"type": "bool", "name": ""}],
             "inputs": [],
             "constant": False,
             "payable": False,

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ envdir =
     py38,plugintest: {toxinidir}/.tox/py38
 deps =
     py{36,37,38},{mix,evm,plugin}test: coverage==4.5.4
-    py{36,37,38},{mix,evm,plugin}test: pytest==5.3.5
+    py{36,37,38},{mix,evm,plugin}test: pytest==5.4.1
     py{36,37,38},{mix,evm,plugin}test: pytest-cov==2.8.1
     py{36,37,38},{mix,evm,plugin}test: pytest-mock==2.0.0
     py{36,37,38},{mix,evm,plugin}test: pytest-xdist==1.31.0


### PR DESCRIPTION
### What I did
* use Vyper `0.1.0b17`, adjust handling of `ast` based on compiler changes
* handle missing `dependencies` field on `Contract` objects
* bump version to `v1.6.8`
