### PR TITLE
Fix an encoding bug for list of tuples.

### DIFF
--- a/brownie/convert/utils.py
+++ b/brownie/convert/utils.py
@@ -19,13 +19,16 @@ def get_type_strings(abi_params: List, substitutions: Optional[Dict] = None) -> 
     if substitutions is None:
         substitutions = {}
     for i in abi_params:
-        if i["type"] != "tuple":
+        if i["type"] == "tuple":
+            params = get_type_strings(i["components"], substitutions)
+            types_list.append(f"({','.join(params)})")
+        elif i["type"] == "tuple[]":
+            params = get_type_strings(i["components"], substitutions)
+            types_list.append(f"({','.join(params)})[]")
+        else:
             type_str = i["type"]
             for orig, sub in substitutions.items():
                 if type_str.startswith(orig):
                     type_str = type_str.replace(orig, sub)
             types_list.append(type_str)
-            continue
-        params = get_type_strings(i["components"], substitutions)
-        types_list.append(f"({','.join(params)})")
     return types_list


### PR DESCRIPTION
If an argument is of type "tuple" it's encoded as the concatenation of
the types that are inside. We should do the same for list of tuples.

This fixes a bug where brownie crashes when trying to encode an argument
with a type "ComplexStruct[]" where ComplexStruct is a solidity struct
with a few fields.

Example Solidity code to reproduce the bug:

```
contract Foo {
    struct Bar {
        uint256 something;
        address something_else;
    }

    function frobulate(Bar[] calldata bar_list) external {
      // do something
    }
}
```

Before that fix, Brownie will crash when encoding the call to frobulate.