### PR TITLE
Add support for passing the --fork option to ganache.

### DIFF
--- a/brownie/network/rpc.py
+++ b/brownie/network/rpc.py
@@ -22,6 +22,7 @@ CLI_FLAGS = {
     "gas_limit": "--gasLimit",
     "accounts": "--accounts",
     "evm_version": "--hardfork",
+    "fork": "--fork",
     "mnemonic": "--mnemonic",
     "account_keys_path": "--acctKeys",
 }


### PR DESCRIPTION
One caveat is: https://github.com/trufflesuite/ganache-cli/issues/722
So for it to work as of now, you need to use a different port than 8545. But if you do that it works perfectly.