### PR TITLE
Fix a DivisionByZeroError in case there is no line covered in a contract

### DIFF
--- a/brownie/test/output.py
+++ b/brownie/test/output.py
@@ -57,7 +57,7 @@ def _cov_color(pct):
 
 
 def _pct(statement, branch):
-    pct = statement[0] / statement[1]
+    pct = statement[0] / (statement[1] or 1)
     if branch[-1]:
         pct = (pct + (branch[0] + branch[1]) / (branch[2] * 2)) / 2
     return pct


### PR DESCRIPTION
"brownie test --coverage" crashed because of that when I included a contract that was left untouched for now.