### PR TITLE
fix: do not pass rpc object to RPCConnectionError

### DIFF
--- a/brownie/exceptions.py
+++ b/brownie/exceptions.py
@@ -25,24 +25,22 @@ class IncompatibleEVMVersion(Exception):
     pass
 
 
-class _RPCBaseException(Exception):
-    def __init__(self, msg: str, cmd: str, proc: Type[psutil.Popen], uri: str) -> None:
-        msg = f"{msg}\n\nCommand: {cmd}\nURI: {uri}\nExit Code: {proc.poll()}"
+class RPCProcessError(Exception):
+    def __init__(self, cmd: str, uri: str) -> None:
+        super().__init__(f"Unable to launch local RPC client.\nCommand: {cmd}\nURI: {uri}")
+
+
+class RPCConnectionError(Exception):
+    def __init__(self, cmd: str, proc: psutil.Popen, uri: str) -> None:
+        msg = (
+            "Able to launch RPC client, but unable to connect."
+            f"\n\nCommand: {cmd}\nURI: {uri}\nExit Code: {proc.poll()}"
+        )
         if sys.platform != "win32":
             out = proc.stdout.read().decode().strip() or "  (Empty)"
             err = proc.stderr.read().decode().strip() or "  (Empty)"
-            msg += f"\n\nStdout:\n{out}\n\nStderr:\n{err}"
+            msg = f"{msg}\n\nStdout:\n{out}\n\nStderr:\n{err}"
         super().__init__(msg)
-
-
-class RPCProcessError(_RPCBaseException):
-    def __init__(self, cmd: str, proc: Type[psutil.Popen], uri: str) -> None:
-        super().__init__("Unable to launch local RPC client.", cmd, proc, uri)
-
-
-class RPCConnectionError(_RPCBaseException):
-    def __init__(self, cmd: str, proc: Type[psutil.Popen], uri: str) -> None:
-        super().__init__("Able to launch RPC client, but unable to connect.", cmd, proc, uri)
 
 
 class RPCRequestError(Exception):

--- a/brownie/network/rpc.py
+++ b/brownie/network/rpc.py
@@ -100,7 +100,7 @@ class Rpc(metaclass=_Singleton):
                 self._rpc.poll()
             if not self._rpc.is_running():
                 self.kill(False)
-                raise RPCProcessError(cmd, self._rpc, uri)
+                raise RPCProcessError(cmd, uri)
         self.kill(False)
         raise RPCConnectionError(cmd, self._rpc, uri)
 
@@ -120,7 +120,10 @@ class Rpc(metaclass=_Singleton):
         try:
             proc = next(i for i in psutil.process_iter() if _check_connections(i, laddr))
         except StopIteration:
-            raise ProcessLookupError("Could not find RPC process.")
+            raise ProcessLookupError(
+                "Could not attach to RPC process. If this issue persists, try killing "
+                "the RPC and let Brownie launch it as a child process."
+            ) from None
         print(f"Attached to local RPC client listening at '{laddr[0]}:{laddr[1]}'...")
         self._rpc = psutil.Process(proc.pid)
         if web3.provider:


### PR DESCRIPTION
### What I did
Fix #374 

### How I did it
Remove base class for RPC errors.

### How to verify it
Run tests.
