### PR TITLE
Add default account setting to Accounts

### DIFF
--- a/brownie/network/account.py
+++ b/brownie/network/account.py
@@ -27,12 +27,19 @@ rpc = Rpc()
 
 
 class Accounts(metaclass=_Singleton):
+    """
+    List-like container that holds all available `Account` objects.
 
-    """List-like container that holds all of the available Account instances."""
+    Attributes
+    ----------
+    default : Account, optional
+        Default account to broadcast transactions from.
+    """
 
     def __init__(self) -> None:
+        self.default = None
         self._accounts: List = []
-        # prevent private keys from being stored in read history
+        # prevent private keys from being stored in readline history
         self.add.__dict__["_private"] = True
         _revert_register(self)
         self._reset()
@@ -43,6 +50,8 @@ class Accounts(metaclass=_Singleton):
             self._accounts = [Account(i) for i in web3.eth.accounts]
         except Exception:
             pass
+        if self.default not in self._accounts:
+            self.default = None
 
     def _revert(self, height: int) -> None:
         # must exist for rpc registry callback

--- a/docs/api-network.rst
+++ b/docs/api-network.rst
@@ -100,9 +100,9 @@ The ``main`` module contains methods for conncting to or disconnecting from the 
 ``brownie.network.account``
 ===========================
 
-The :func:`Account <brownie.network.account.Account>` module holds classes for interacting with Ethereum accounts for which you control the private key.
+The ``account`` module holds classes for interacting with Ethereum accounts for which you control the private key.
 
-Classes in this module are not meant to be instantiated directly. The :func:`Accounts <brownie.network.account.Accounts>` container is available as :func:`Account <brownie.network.account.Accounts>` (or just ``a``) and will create each :func:`Account <brownie.network.account.Account>` automatically during initialization. Add more accounts using :func:`Accounts.add <Accounts.add>`.
+Classes in this module are not meant to be instantiated directly. The :func:`Accounts <brownie.network.account.Accounts>` container is available as ``accounts`` (or just ``a``) and will create each :func:`Account <brownie.network.account.Account>` automatically during initialization. Add more accounts using :func:`Accounts.add <Accounts.add>`.
 
 Accounts
 --------
@@ -118,6 +118,20 @@ Accounts
         [<Account object '0x7Ebaa12c5d1EE7fD498b51d4F9278DC45f8D627A'>, <Account object '0x186f79d227f5D819ACAB0C529031036D11E0a000'>, <Account object '0xC53c27492193518FE9eBff00fd3CBEB6c434Cf8b'>, <Account object '0x2929AF7BBCde235035ED72029c81b71935c49e94'>, <Account object '0xb93538FEb07b3B8433BD394594cA3744f7ee2dF1'>, <Account object '0x1E563DBB05A10367c51A751DF61167dE99A4d0A7'>, <Account object '0xa0942deAc0885096D8400D3369dc4a2dde12875b'>, <Account object '0xf427a9eC1d510D77f4cEe4CF352545071387B2e6'>, <Account object '0x2308D528e4930EFB4aF30793A3F17295a0EFa886'>, <Account object '0x2fb37EB570B1eE8Eda736c1BD1E82748Ec3d0Bf1'>]
         >>> dir(accounts)
         [add, at, clear, load, remove]
+
+Accounts Attributes
+*******************
+
+.. py:attribute:: Accounts.default
+
+    Default account that is used for deploying contracts.  Initially set to ``None``.
+
+    Note that the default account used to send contract transactions is the one that deployed the contract, not ``accounts.default``.
+
+    .. code-block:: python
+
+        >>> accounts.default = accounts[1]
+
 
 Accounts Methods
 ****************

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -262,7 +262,8 @@ def devnetwork(network, rpc):
 
 @pytest.fixture
 def accounts(devnetwork):
-    return brownie.network.accounts
+    yield brownie.network.accounts
+    brownie.network.accounts.default = None
 
 
 @pytest.fixture(scope="session")
@@ -296,6 +297,7 @@ def web3():
 @pytest.fixture
 def config():
     initial = brownie.config._copy()
+    brownie.config._unlock()
     yield brownie.config
     brownie.config._unlock()
     brownie.config.clear()

--- a/tests/main/test_config.py
+++ b/tests/main/test_config.py
@@ -26,6 +26,7 @@ def test_network_keys(config):
 
 
 def test_setitem(config):
+    config._lock()
     with pytest.raises(KeyError):
         config["foo"] = "bar"
     config._unlock()

--- a/tests/network/account/test_accounts.py
+++ b/tests/network/account/test_accounts.py
@@ -81,3 +81,15 @@ def test_delete(accounts):
     del accounts[-1]
     assert len(accounts) == 9
     assert a not in accounts
+
+
+def test_default_remains_after_reset(accounts):
+    accounts.default = accounts[0]
+    accounts._reset()
+    assert accounts.default == accounts[0]
+
+
+def test_default_cleared_on_disconnect(accounts, network):
+    accounts.default = accounts[0]
+    network.disconnect()
+    assert accounts.default is None

--- a/tests/network/contract/test_contractconstructor.py
+++ b/tests/network/contract/test_contractconstructor.py
@@ -84,11 +84,6 @@ def test_gas_limit_config(BrownieTester, accounts, config):
     config["active_network"]["gas_limit"] = False
 
 
-def test_no_from(BrownieTester):
-    with pytest.raises(AttributeError):
-        BrownieTester.deploy(True)
-
-
 def test_repr(BrownieTester, accounts):
     repr(BrownieTester)
     repr(BrownieTester.deploy)

--- a/tests/network/contract/test_contracttx.py
+++ b/tests/network/contract/test_contracttx.py
@@ -40,28 +40,6 @@ def test_encode_input(tester):
     )
 
 
-def test_cli_no_owner(BrownieTester, accounts, test_mode, config):
-    try:
-        config._unlock()
-        config["active_network"]["default_contract_owner"] = False
-        tester = BrownieTester.deploy(True, {"from": accounts[0]})
-        assert tester.revertStrings._owner is None
-    finally:
-        del config["active_network"]["default_contract_owner"]
-        config._lock()
-
-
-def test_no_from(tester, accounts):
-    nonce = accounts[0].nonce
-    tx = tester.revertStrings(5)
-    assert tx.sender == accounts[0]
-    assert accounts[0].nonce == nonce + 1
-    tester.revertStrings._owner = None
-    with pytest.raises(AttributeError):
-        tester.revertStrings(5)
-    tester.revertStrings._owner = accounts[0]
-
-
 def test_call(tester, accounts):
     nonce = accounts[0].nonce
     result = tester.revertStrings.call(5, {"from": accounts[0]})

--- a/tests/network/contract/test_default_sender.py
+++ b/tests/network/contract/test_default_sender.py
@@ -1,0 +1,53 @@
+import pytest
+
+from brownie.project import compile_source
+
+TEST_SOURCE = """
+pragma solidity ^0.6.0;
+
+contract Foo {
+    constructor () public {}
+    function bar() public {}
+}
+"""
+
+
+@pytest.fixture
+def Foo():
+    yield compile_source(TEST_SOURCE).Foo
+
+
+def test_cli_no_owner(Foo, accounts, test_mode, config):
+    config["active_network"]["default_contract_owner"] = False
+    foo = Foo.deploy({"from": accounts[0]})
+
+    with pytest.raises(AttributeError):
+        foo.bar()
+
+
+def test_without_from_sends_from_deployer(Foo, accounts):
+    foo = Foo.deploy({"from": accounts[0]})
+    tx = foo.bar()
+
+    assert tx.sender == accounts[0]
+
+
+def test_deploy_with_default_account(Foo, accounts):
+    accounts.default = accounts[1]
+    foo = Foo.deploy()
+
+    assert foo.tx.sender == accounts[1]
+
+
+def test_deploy_without_default_account(Foo, accounts):
+    assert accounts.default is None
+    with pytest.raises(AttributeError):
+        Foo.deploy()
+
+
+def test_contract_owner_overrides_default_account(Foo, accounts):
+    accounts.default = accounts[1]
+    foo = Foo.deploy({"from": accounts[2]})
+    tx = foo.bar()
+
+    assert tx.sender == accounts[2]


### PR DESCRIPTION
### What I did
Add `Accounts.default` as a way to declare a default account for deploying contracts - Closes #289 

### How to verify it
Run updated tests.

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [x] I have included test cases
- [x] I have updated the documentation
- [ ] I have added an entry to the changelog
