### PR TITLE
fix: bump solcast version to fix recursion issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ hypothesis==5.5.4
 psutil>=5.7.0,<6.0.0
 py>=1.5.0
 pyreadline==2.1;platform_system=='Windows'
-py-solc-ast>=1.2.2,<2.0.0
+py-solc-ast>=1.2.3,<2.0.0
 py-solc-x>=0.8.1,<1.0.0
 pytest==5.4.1
 pytest-xdist==1.31.0


### PR DESCRIPTION
### What I did
Bump `py-solc-ast` dependency version to fix an issue with recursion. Fixes #392.