### PR TITLE
build: split travis jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,21 @@
 # Based on https://github.com/cclauss/Travis-CI-Python-on-three-OSes
 jobs:
   include:
-    - name: "EVM Tests - Python 3.7 on Bionic Linux"
+    - name: Linting
+      language: python
+      python: 3.6
+      dist: bionic
+      install:
+        - python -m pip install coveralls==1.9.2 tox==3.14.3
+      script: tox -e lint
+    - name: Documentation
+      language: python
+      python: 3.6
+      dist: bionic
+      install:
+        - python -m pip install coveralls==1.9.2 tox==3.14.3
+      script: tox -e doctest
+    - name: EVM Tests - Python 3.7 (Linux)
       language: python
       python: 3.7
       dist: bionic
@@ -11,25 +25,7 @@ jobs:
         - sudo apt-get update
         - sudo apt-get install -y python3.7-dev npm solc
       script: tox -e evmtest
-    - name: "Standard Tests - Python 3.8 on Windows"
-      os: windows
-      language: node_js
-      node_js: '10'
-      before_install:
-        - choco install python --version=3.8.0
-      env: PATH=/c/Python38:/c/Python38/Scripts:$PATH
-      script: tox -e py38
-    - name: "Standard Tests, Linting, Docs - Python 3.6 on Bionic Linux"
-      language: python
-      python: 3.6
-      dist: bionic
-      before_install:
-        - sudo add-apt-repository -y ppa:ethereum/ethereum
-        - sudo add-apt-repository -y ppa:deadsnakes/ppa
-        - sudo apt-get update
-        - sudo apt-get install -y python3.6-dev npm solc
-      script: tox -e lint,doctest,py36
-    - name: "Standard Tests, Package Tests - Python 3.7 on Bionic Linux"
+    - name: Package Tests - Python 3.7 (Linux)
       language: python
       python: 3.7
       dist: bionic
@@ -38,8 +34,46 @@ jobs:
         - sudo add-apt-repository -y ppa:deadsnakes/ppa
         - sudo apt-get update
         - sudo apt-get install -y python3.6-dev npm solc
-      script: tox -e py37,pmtest
-    - name: "Standard Tests, Plugin Tests - Python 3.8 on Bionic Linux"
+      script: tox -e pmtest
+    - name: Plugin Tests - Python 3.7 (Linux)
+      language: python
+      python: 3.7
+      dist: bionic
+      before_install:
+        - sudo add-apt-repository -y ppa:ethereum/ethereum
+        - sudo add-apt-repository -y ppa:deadsnakes/ppa
+        - sudo apt-get update
+        - sudo apt-get install -y python3.8-dev npm solc
+      script: tox -e plugintest
+    - name: Standard Tests - Python 3.8 (Windows)
+      os: windows
+      language: node_js
+      node_js: '10'
+      before_install:
+        - choco install python --version=3.8.0
+      env: PATH=/c/Python38:/c/Python38/Scripts:$PATH
+      script: tox -e py38
+    - name: Standard Tests - Python 3.6 (Linux)
+      language: python
+      python: 3.6
+      dist: bionic
+      before_install:
+        - sudo add-apt-repository -y ppa:ethereum/ethereum
+        - sudo add-apt-repository -y ppa:deadsnakes/ppa
+        - sudo apt-get update
+        - sudo apt-get install -y python3.6-dev npm solc
+      script: tox -e py36
+    - name: "Standard Tests - Python 3.7 (Linux)"
+      language: python
+      python: 3.7
+      dist: bionic
+      before_install:
+        - sudo add-apt-repository -y ppa:ethereum/ethereum
+        - sudo add-apt-repository -y ppa:deadsnakes/ppa
+        - sudo apt-get update
+        - sudo apt-get install -y python3.6-dev npm solc
+      script: tox -e py37
+    - name: Standard Tests - Python 3.8 (Linux)
       language: python
       python: 3.8
       dist: bionic
@@ -48,7 +82,7 @@ jobs:
         - sudo add-apt-repository -y ppa:deadsnakes/ppa
         - sudo apt-get update
         - sudo apt-get install -y python3.8-dev npm solc
-      script: tox -e py38,plugintest
+      script: tox -e py38
 
 env:
   global: COVERALLS_PARALLEL=true

--- a/tests/project/packages/test_popular_packages.py
+++ b/tests/project/packages/test_popular_packages.py
@@ -2,7 +2,7 @@ import pytest
 
 from brownie.project.main import install_package
 
-PACKAGES = ["OpenZeppelin/openzeppelin-contracts@2.5.0", "aragon/aragonOS@4.0.0"]
+PACKAGES = ["OpenZeppelin/openzeppelin-contracts@2.5.0", "aragon/aragonOS@4.4.0"]
 
 
 @pytest.mark.parametrize("package_id", PACKAGES)


### PR DESCRIPTION
### What I did
Separate the travis jobs. Now that we can run 7 jobs at once, it should be quicker this way. Also it means when doctest fails from an external link, it's a lot less time to re-run it.
