### PR TITLE
Natspec

### DIFF
--- a/brownie/project/build.py
+++ b/brownie/project/build.py
@@ -17,6 +17,7 @@ BUILD_KEYS = [
     "deployedSourceMap",
     "dependencies",
     "language",
+    "natspec",
     "offset",
     "opcodes",
     "pcMap",

--- a/brownie/project/compiler/__init__.py
+++ b/brownie/project/compiler/__init__.py
@@ -18,6 +18,7 @@ from brownie.project.compiler.solidity import (  # NOQA: F401
     install_solc,
     set_solc_version,
 )
+from brownie.project.compiler.utils import merge_natspec
 from brownie.utils import notify
 
 from . import solidity, vyper
@@ -27,7 +28,10 @@ STANDARD_JSON: Dict = {
     "sources": {},
     "settings": {
         "outputSelection": {
-            "*": {"*": ["abi", "evm.bytecode", "evm.deployedBytecode"], "": ["ast"]}
+            "*": {
+                "*": ["abi", "devdoc", "evm.bytecode", "evm.deployedBytecode", "userdoc"],
+                "": ["ast"],
+            }
         },
         "evmVersion": None,
         "remappings": [],
@@ -273,6 +277,10 @@ def generate_build_json(
             print(f" - {contract_name}...")
 
         abi = output_json["contracts"][path_str][contract_name]["abi"]
+        natspec = merge_natspec(
+            output_json["contracts"][path_str][contract_name]["devdoc"],
+            output_json["contracts"][path_str][contract_name]["userdoc"],
+        )
         output_evm = output_json["contracts"][path_str][contract_name]["evm"]
 
         if input_json["language"] == "Solidity":
@@ -307,6 +315,7 @@ def generate_build_json(
                 "deployedBytecode": output_evm["deployedBytecode"]["object"],
                 "deployedSourceMap": output_evm["deployedBytecode"]["sourceMap"],
                 "language": input_json["language"],
+                "natspec": natspec,
                 "opcodes": output_evm["deployedBytecode"]["opcodes"],
                 "sha1": sha1(input_json["sources"][path_str]["content"].encode()).hexdigest(),
                 "source": input_json["sources"][path_str]["content"],

--- a/brownie/project/compiler/utils.py
+++ b/brownie/project/compiler/utils.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 
-from typing import List
+from typing import Dict, List
 
 
 def expand_source_map(source_map_str: str) -> List:
@@ -23,3 +23,29 @@ def _expand_row(row: str) -> List:
         if value:
             result[i] = value if i == 3 else int(value)
     return result
+
+
+def merge_natspec(devdoc: Dict, userdoc: Dict) -> Dict:
+    """
+    Merge devdoc and userdoc compiler output to a single dict.
+
+    Arguments
+    ---------
+    devdoc: dict
+        Devdoc compiler output.
+    userdoc : dict
+        Userdoc compiler output.
+
+    Returns
+    -------
+    dict
+        Combined natspec.
+    """
+    natspec = {**userdoc, **devdoc}
+    for key in set(list(userdoc["methods"]) + list(devdoc["methods"])):
+        natspec["methods"][key] = {
+            **userdoc["methods"].get(key, {}),
+            **devdoc["methods"].get(key, {}),
+        }
+
+    return natspec

--- a/brownie/project/compiler/utils.py
+++ b/brownie/project/compiler/utils.py
@@ -41,13 +41,13 @@ def merge_natspec(devdoc: Dict, userdoc: Dict) -> Dict:
     dict
         Combined natspec.
     """
-    natspec = {**userdoc, **devdoc}
-    for key in set(list(userdoc["methods"]) + list(devdoc["methods"])):
+    natspec: Dict = {**{"methods": {}}, **userdoc, **devdoc}
+    usermethods = userdoc.get("methods", {})
+    devmethods = devdoc.get("methods", {})
+
+    for key in set(list(usermethods) + list(devmethods)):
         try:
-            natspec["methods"][key] = {
-                **userdoc["methods"].get(key, {}),
-                **devdoc["methods"].get(key, {}),
-            }
+            natspec["methods"][key] = {**usermethods.get(key, {}), **devmethods.get(key, {})}
         except TypeError:
             # sometimes Solidity has inconsistent NatSpec formatting ¯\_(ツ)_/¯
             pass

--- a/brownie/project/compiler/utils.py
+++ b/brownie/project/compiler/utils.py
@@ -43,9 +43,12 @@ def merge_natspec(devdoc: Dict, userdoc: Dict) -> Dict:
     """
     natspec = {**userdoc, **devdoc}
     for key in set(list(userdoc["methods"]) + list(devdoc["methods"])):
-        natspec["methods"][key] = {
-            **userdoc["methods"].get(key, {}),
-            **devdoc["methods"].get(key, {}),
-        }
-
+        try:
+            natspec["methods"][key] = {
+                **userdoc["methods"].get(key, {}),
+                **devdoc["methods"].get(key, {}),
+            }
+        except TypeError:
+            # sometimes Solidity has inconsistent NatSpec formatting ¯\_(ツ)_/¯
+            pass
     return natspec

--- a/docs/api-network.rst
+++ b/docs/api-network.rst
@@ -851,6 +851,21 @@ ContractCall Attributes
 ContractCall Methods
 ********************
 
+.. py:classmethod:: ContractCall.info()
+
+    Display `NatSpec documentation <https://solidity.readthedocs.io/en/latest/natspec-format.html>`_ documentation for the given method.
+
+    .. code-block:: python
+
+        >>> Token[0].allowance.info()
+        allowance(address _owner, address _spender)
+          @dev Function to check the amount of tokens than an owner
+               allowed to a spender.
+          @param _owner address The address which owns the funds.
+          @param _spender address The address which will spend the funds.
+          @return A uint specifying the amount of tokens still available
+                  for the spender.
+
 .. py:classmethod:: ContractCall.transact(*args)
 
     Sends a transaction to the method and returns a :func:`TransactionReceipt <brownie.network.transaction.TransactionReceipt>`.
@@ -931,6 +946,15 @@ ContractTx Methods
         >>> Token[0].transfer.call(accounts[2], 10000, {'from': accounts[0]})
         True
 
+.. py:classmethod:: ContractTx.decode_output(hexstr)
+
+    Decodes raw hexstring data returned by this method.
+
+    .. code-block:: python
+
+        >>>  Token[0].balanceOf.decode_output("0x00000000000000000000000000000000000000000000003635c9adc5dea00000")
+        1000000000000000000000
+
 .. py:classmethod:: ContractTx.encode_input(*args)
 
     Returns a hexstring of ABI calldata that can be used to call the method with the given arguments.
@@ -945,16 +969,17 @@ ContractTx Methods
         Token.transfer confirmed - block: 2   gas used: 50985 (100.00%)
         <Transaction object '0x8dbf15878104571669f9843c18afc40529305ddb842f94522094454dcde22186'>
 
+.. py:classmethod:: ContractTx.info()
 
-.. py:classmethod:: ContractTx.decode_output(hexstr)
-
-    Decodes raw hexstring data returned by this method.
+    Display `NatSpec documentation <https://solidity.readthedocs.io/en/latest/natspec-format.html>`_ documentation for the given method.
 
     .. code-block:: python
 
-        >>>  Token[0].balanceOf.decode_output("0x00000000000000000000000000000000000000000000003635c9adc5dea00000")
-        1000000000000000000000
-
+        >>> Token[0].transfer.info()
+        transfer(address _to, uint256 _value)
+          @dev transfer token for a specified address
+          @param _to The address to transfer to.
+          @param _value The amount to be transferred.
 
 OverloadedMethod
 ----------------

--- a/docs/core-contracts.rst
+++ b/docs/core-contracts.rst
@@ -99,6 +99,17 @@ All public contract methods are available from the :func:`Contract <brownie.netw
     >>> Token[0].balanceOf
     <ContractCall object 'balanceOf(address _owner)'>
 
+When a contract source includes `NatSpec documentation <https://solidity.readthedocs.io/en/latest/natspec-format.html>`_, you can view it via the :func:`ContractCall.info <ContractCall.info>` method:
+
+.. code-block:: python
+
+    >>> Token[0].transfer.info()
+    transfer(address _to, uint256 _value)
+      @dev transfer token for a specified address
+      @param _to The address to transfer to.
+      @param _value The amount to be transferred.
+
+
 Transactions
 ------------
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -106,13 +106,16 @@ Here is an example of checking a balance and transfering some ether:
 
     >>> accounts[0]
     <Account object '0xC0BcE0346d4d93e30008A1FE83a2Cf8CfB9Ed301'>
+
     >>> accounts[1].balance()
     100000000000000000000
+
     >>> accounts[0].transfer(accounts[1], "10 ether")
 
     Transaction sent: 0x124ba3f9f9e5a8c5e7e559390bebf8dfca998ef32130ddd114b7858f255f6369
     Transaction confirmed - block: 1   gas spent: 21000
     <Transaction object '0x124ba3f9f9e5a8c5e7e559390bebf8dfca998ef32130ddd114b7858f255f6369'>
+
     >>> accounts[1].balance()
     110000000000000000000
 
@@ -127,15 +130,17 @@ Brownie provides a :func:`ContractContainer <brownie.network.contract.ContractCo
 
     >>> Token
     []
+
     >>> Token.deploy
     <ContractConstructor object 'Token.constructor(string _symbol, string _name, uint256 _decimals, uint256 _totalSupply)'>
+
     >>> t = Token.deploy("Test Token", "TST", 18, 1e20, {'from': accounts[1]})
 
     Transaction sent: 0x2e3cab83342edda14141714ced002e1326ecd8cded4cd0cf14b2f037b690b976
     Transaction confirmed - block: 1   gas spent: 594186
     Contract deployed at: 0x5419710735c2D6c3e4db8F30EF2d361F70a4b380
     <Token Contract object '0x5419710735c2D6c3e4db8F30EF2d361F70a4b380'>
-    >>>
+
     >>> t
     <Token Contract object '0x5419710735c2D6c3e4db8F30EF2d361F70a4b380'>
 
@@ -147,21 +152,34 @@ When a contact is deployed you are returned a :func:`Contract <brownie.network.c
 
     >>> t
     <Token Contract object '0x5419710735c2D6c3e4db8F30EF2d361F70a4b380'>
+
     >>> t.balanceOf(accounts[1])
     1000000000000000000000
 
     >>> t.transfer
     <ContractTx object 'transfer(address _to, uint256 _value)'>
+
     >>> t.transfer(accounts[2], 1e20, {'from': accounts[1]})
 
     Transaction sent: 0xcd98225a77409b8d81023a3a4be15832e763cd09c74ff431236bfc6d56a74532
     Transaction confirmed - block: 2   gas spent: 51241
     <Transaction object '0xcd98225a77409b8d81023a3a4be15832e763cd09c74ff431236bfc6d56a74532'>
-    >>>
+
     >>> t.balanceOf(accounts[1])
     900000000000000000000
+
     >>> t.balanceOf(accounts[2])
     100000000000000000000
+
+When a contract source includes `NatSpec documentation <https://solidity.readthedocs.io/en/latest/natspec-format.html>`_, you can view it via the :func:`ContractCall.info <ContractCall.info>` method:
+
+.. code-block:: python
+
+    >>> t.transfer.info()
+    transfer(address _to, uint256 _value)
+      @dev transfer token for a specified address
+      @param _to The address to transfer to.
+      @param _value The amount to be transferred.
 
 Transactions
 ------------
@@ -180,16 +198,16 @@ The :func:`TransactionReceipt <brownie.network.transaction.TransactionReceipt>` 
     >>> tx
     <Transaction object '0x0d96e8ceb555616fca79dd9d07971a9148295777bb767f9aa5b34ede483c9753'>
 
-To examine the events that fired:
+Use :func:`TransactionReceipt.events <TransactionReceipt.events>` to examine the events that fired:
 
 .. code-block:: python
 
-    >>> tx.events()
-
     >>> len(tx.events)
+    1
 
     >>> 'Transfer' in tx.events
     True
+
     >>> tx.events['Transfer']
     {
         'from': "0x4fe357adbdb4c6c37164c54640851d6bff9296c8",
@@ -204,9 +222,9 @@ To inspect the transaction trace:
     >>> tx.call_trace()
     Call trace for '0x0d96e8ceb555616fca79dd9d07971a9148295777bb767f9aa5b34ede483c9753':
     Token.transfer 0:244  (0x4A32104371b05837F2A36dF6D850FA33A92a178D)
-      ∟ Token.transfer 72:226
-      ∟ SafeMath.sub 100:114
-      ∟ SafeMath.add 149:165
+      ├─Token.transfer 72:226
+      ├─SafeMath.sub 100:114
+      └─SafeMath.add 149:165
 
 For information on why a transaction reverted:
 
@@ -281,7 +299,7 @@ Here is an example test function using Brownie's automatically generated fixture
         assert token.balanceOf(accounts[1]) == 1e19
         assert token.balanceOf(accounts[0]) == 9e19
 
-A complete list of Brownie fixtures is available here.
+See the :ref:`Pytest Fixtures <pytest-fixtures-reference>` section for a complete list of fixtures.
 
 Handling Reverted Transactions
 ------------------------------

--- a/tests/network/contract/test_natspec_info.py
+++ b/tests/network/contract/test_natspec_info.py
@@ -1,0 +1,107 @@
+import pytest
+
+from brownie.project import compile_source
+
+solc_natspec = """
+pragma solidity >=0.5.0;
+
+/**
+    @title A simulator for Bug Bunny, the most famous Rabbit
+    @author Warned Bros
+    @notice You can use this contract for only the most basic simulation
+    @dev
+        Simply chewing a carrot does not count, carrots must pass
+        the throat to be considered eaten
+ */
+contract Bugs {
+    /**
+        @notice Determine if Bugs will accept `qty` of `food` to eat
+        @dev Compares the entire string and does not rely on a hash
+        @param food The name of a food to evaluate (in English)
+        @param qty The number of food items to evaluate
+        @return True if Bugs will eat it, False otherwise
+        @return A second value for testing purposes
+     */
+    function doesEat(uint256 food, uint256 qty) external returns (bool, bool) {
+        return (true, false);
+    }
+}
+"""
+
+vyper_natspec = '''
+"""
+@title A simulator for Bug Bunny, the most famous Rabbit
+@author Warned Bros
+@notice You can use this contract for only the most basic simulation
+@dev
+    Simply chewing a carrot does not count, carrots must pass
+    the throat to be considered eaten
+"""
+
+@public
+@payable
+def doesEat(food: string[30], qty: uint256) -> (bool, bool):
+    """
+    @notice Determine if Bugs will accept `qty` of `food` to eat
+    @dev Compares the entire string and does not rely on a hash
+    @param food The name of a food to evaluate (in English)
+    @param qty The number of food items to evaluate
+    @return True if Bugs will eat it, False otherwise
+    @return A second value for testing purposes
+    """
+    return True, False
+'''
+
+
+@pytest.mark.parametrize("version", [5, 6])
+def test_solc_contract(version, capfd):
+    code = solc_natspec
+    contract = compile_source(code, solc_version=f"0.{version}.0").Bugs
+
+    contract.info()
+
+    out = capfd.readouterr()[0]
+    for field in ("title", "author", "notice", "details"):
+        assert f"@{field}" in out
+
+
+@pytest.mark.parametrize("version", [5, 6])
+def test_solc_function(version, capfd, accounts):
+    code = solc_natspec
+    contract = compile_source(code, solc_version=f"0.{version}.0").Bugs
+    contract.deploy({"from": accounts[0]})
+
+    contract[0].doesEat.info()
+
+    out = capfd.readouterr()[0]
+    for field in ("notice", "details"):
+        assert f"@{field}" in out
+
+    assert out.count("@param") == 2
+    assert out.count("@return") == 2 if version == 6 else 1
+
+
+def test_vyper_contract(capfd):
+    code = vyper_natspec
+    contract = compile_source(code).Vyper
+
+    contract.info()
+
+    out = capfd.readouterr()[0]
+    for field in ("title", "author", "notice", "details"):
+        assert f"@{field}" in out
+
+
+def test_vyper_function(capfd, accounts):
+    code = vyper_natspec
+    contract = compile_source(code).Vyper
+    contract.deploy({"from": accounts[0]})
+
+    contract[0].doesEat.info()
+
+    out = capfd.readouterr()[0]
+    for field in ("notice", "details"):
+        assert f"@{field}" in out
+
+    assert out.count("@param") == 2
+    assert out.count("@return") == 2

--- a/tests/project/compiler/test_natspec.py
+++ b/tests/project/compiler/test_natspec.py
@@ -1,0 +1,55 @@
+from brownie.project.compiler.utils import merge_natspec
+
+DEVDOC = {
+    "author": "Warned Bros",
+    "details": "Simply chewing a carrot does not count, carrots must pass the throat",
+    "methods": {
+        "age(uint256,uint256)": {
+            "details": "Compares the entire string and does not rely on a hash",
+            "params": {
+                "food": "The name of a food to evaluate (in English)",
+                "qty": "The number of food items to evaluate",
+            },
+            "returns": {
+                "_0": "True if Bugs will eat it, False otherwise",
+                "_1": "A second value for testing purposes",
+            },
+        }
+    },
+    "title": "A simulator for Bug Bunny, the most famous Rabbit",
+}
+
+USERDOC = {
+    "methods": {
+        "constructor": "I'm only here to mess with things",
+        "age(uint256,uint256)": {"notice": "Determine if Bugs will accept `qty` of `food` to eat"},
+    },
+    "notice": "You can use this contract for only the most basic simulation",
+}
+
+
+def test_userdoc():
+    natspec = merge_natspec(DEVDOC, USERDOC)
+
+    assert USERDOC["notice"] == natspec["notice"]
+    assert "constructor" not in natspec["methods"]
+
+    notice = USERDOC["methods"]["age(uint256,uint256)"]["notice"]
+    assert notice == natspec["methods"]["age(uint256,uint256)"]["notice"]
+
+
+def test_devdoc():
+    natspec = merge_natspec(DEVDOC, USERDOC)
+
+    for key in DEVDOC:
+        if key == "methods":
+            continue
+        assert DEVDOC[key] == natspec[key]
+
+
+def test_devdoc_methods():
+    natspec = merge_natspec(DEVDOC, USERDOC)
+
+    methods = DEVDOC["methods"]["age(uint256,uint256)"]
+    for key in methods:
+        assert methods[key] == natspec["methods"]["age(uint256,uint256)"][key]


### PR DESCRIPTION
### What I did
Add `Contract.info` and `ContractTx.info` methods to view NatSpec documentation in the console.
Closes #378 

### How I did it
1. In `brownie.project.compiler.utils`, the `merge_natspec` method combines `userdoc` and `devdoc` into a single dict, which is included in the build artifact for each contract.
2. In `brownie.network.contract`, the `_print_natspec` converts the natspec dict into human readable form and outputs to stdout.

### How to verify it
Run tests. I added new cases, including checks against solc `v0.5.0` (single return field) and `v0.6.0` (multiple return fields) as well a vyper.

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [x] I have included test cases
- [x] I have updated the documentation
- [ ] I have added an entry to the changelog
