### PR TITLE
Pytest stdout capturing

### DIFF
--- a/brownie/_cli/test.py
+++ b/brownie/_cli/test.py
@@ -21,6 +21,7 @@ Brownie Options:
   --network [name]         Use a specific network (default {CONFIG['network']['default']})
 
 Pytest Options:
+  -s                       Disable stdout capture when running tests
   -n [numprocesses]        Number of workers to use for xdist distributed testing,
                            set to 'auto' for automatic detection of number of CPUs
   --durations [num]        show slowest setup/test durations (num=0 for all)

--- a/brownie/test/plugin.py
+++ b/brownie/test/plugin.py
@@ -43,6 +43,10 @@ def pytest_configure(config):
         active_project.load_config()
         active_project._add_to_main_namespace()
 
+        # enable verbose output if stdout capture is disabled
+        if config.getoption("capture") == "no":
+            config.option.verbose = True
+
         if config.getoption("numprocesses"):
             Plugin = PytestBrownieMaster
         elif hasattr(config, "workerinput"):

--- a/tests/test/plugin/test_output.py
+++ b/tests/test/plugin/test_output.py
@@ -7,6 +7,7 @@ from brownie.test import output
 test_source = """
 def test_stuff(BrownieTester, accounts):
     c = accounts[0].deploy(BrownieTester, True)
+    print('oh hai mark')
     c.doNothing({'from': accounts[0]})"""
 
 
@@ -41,3 +42,11 @@ def test_coverage_save_report(plugintester):
     next(path.glob("*")).open("w").write("this isn't json, is it?")
     plugintester.runpytest("-C")
     assert [i.name for i in path.glob("*")] == ["coverage.json"]
+
+
+def test_stdout_capture(plugintester):
+    result = plugintester.runpytest("-s")
+    output = result.stdout.str()
+
+    assert output.count("::test_stuff") == 2
+    assert "oh hai mark" in output


### PR DESCRIPTION
### What I did
1. Allow `-s` flag in `brownie test`
2. Add `PytestPrinter` class to improve readability of output when stdout capture is disabled.

Closes #389 

### How I did it
1. When stdout capture is disabled, verbose output is automatically enabled.
2. `PytestPrinter` replaces the builtin `print` method during test execution to:
  a. add a newline before the first line
  b. add a second test id prior to reporting the test result

The final output ends up looking something like this:

```
tests/test_transfer.py::test_transfer RUNNING
this is some text from a call to print
tests/test_transfer.py::test_transfer PASSED
```

### How to verify it
Run tests.
