### PR TITLE
Bugfixes

### DIFF
--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -537,7 +537,7 @@ class ContractCall(_ContractMethod):
             return self.call(*args)
         rpc._internal_snap()
         args, tx = _get_tx(self._owner, args)
-        tx["gas_price"] = 0
+        tx.update({"gas_price": 0, "from": self._owner})
         try:
             tx = self.transact(*args, tx)
             return tx.return_value

--- a/brownie/project/main.py
+++ b/brownie/project/main.py
@@ -167,6 +167,10 @@ class Project(_ProjectBase):
             if not set(BUILD_KEYS).issubset(build_json) or path.stem not in contract_list:
                 path.unlink()
                 continue
+            if isinstance(build_json["allSourcePaths"], list):
+                # this handles the format change in v1.7.0, it can be removed in a future release
+                path.unlink()
+                continue
             self._build._add(build_json)
 
         self._compiler_config = _load_project_compiler_config(self._path)

--- a/tests/network/contract/test_contractcall.py
+++ b/tests/network/contract/test_contractcall.py
@@ -40,3 +40,8 @@ def test_tuples(tester, accounts):
     value = ["blahblah", accounts[1], ["yesyesyes", "0x1234"]]
     tester.setTuple(value)
     assert tester.getTuple(accounts[1], {"from": accounts[0]}) == value
+
+
+def test_default_owner_with_coverage(tester, coverage_mode, accounts, config):
+    config["active_network"]["default_contract_owner"] = False
+    tester.getTuple(accounts[0])


### PR DESCRIPTION
### What I did
More bugfixes.

* "you must specify an owner" during contract calls when evaluating coverage
* trigger a recompile when the old build artifact format is encountered, instead of crashing

Thanks again to @celioggr for pointing these issues out!
