### PR TITLE
Updates to persistence

### DIFF
--- a/brownie/__init__.py
+++ b/brownie/__init__.py
@@ -9,6 +9,7 @@ from brownie.network.contract import Contract  # NOQA: F401
 config = _CONFIG.settings
 
 __all__ = [
+    "Contract",
     "accounts",  # accounts is an Accounts singleton
     "alert",
     "history",  # history is a TxHistory singleton

--- a/brownie/_cli/networks.py
+++ b/brownie/_cli/networks.py
@@ -80,19 +80,19 @@ def _list(verbose=False):
         for value in chain["networks"]:
             is_last = value == chain["networks"][-1]
             if verbose:
-                _print_verbose(value, is_last)
+                _print_verbose_network_description(value, is_last)
             else:
-                _print_simple(value, is_last)
+                _print_simple_network_description(value, is_last)
 
     print("\nDevelopment")
     for value in networks["development"]:
         is_last = value == networks["development"][-1]
         if verbose:
             settings = value.pop("cmd_settings")
-            _print_verbose(value, value == networks["development"][-1])
-            _print_verbose(settings, value == networks["development"][-1], 2)
+            _print_verbose_network_description(value, value == networks["development"][-1])
+            _print_verbose_network_description(settings, value == networks["development"][-1], 2)
         else:
-            _print_simple(value, is_last)
+            _print_simple_network_description(value, is_last)
 
 
 def _add(env, id_, *args):
@@ -132,6 +132,7 @@ def _add(env, id_, *args):
     notify(
         "SUCCESS", f"A new network '{color('bright magenta')}{new['name']}{color}' has been added"
     )
+    _print_verbose_network_description(new, True)
 
 
 def _modify(id_, *args):
@@ -171,6 +172,7 @@ def _modify(id_, *args):
     notify(
         "SUCCESS", f"Network '{color('bright magenta')}{target['name']}{color}' has been modified"
     )
+    _print_verbose_network_description(target, True)
 
 
 def _delete(id_):
@@ -272,27 +274,27 @@ def _parse_args(args):
     return args
 
 
-def _print_simple(obj, is_last):
+def _print_simple_network_description(network_dict, is_last):
     u = "\u2514" if is_last else "\u251c"
     print(
-        f"{color('bright black')}  {u}\u2500{color}{obj['name']}:"
-        f" {color('green')}{obj['id']}{color}"
+        f"{color('bright black')}  {u}\u2500{color}{network_dict['name']}:"
+        f" {color('green')}{network_dict['id']}{color}"
     )
 
 
-def _print_verbose(obj, is_last, indent=0):
+def _print_verbose_network_description(network_dict, is_last, indent=0):
     u = "\u2514" if is_last else "\u251c"
     v = " " if is_last else "\u2502"
-    if "name" in obj:
-        print(f"{color('bright black')}  {u}\u2500{color}{obj.pop('name')}")
+    if "name" in network_dict:
+        print(f"{color('bright black')}  {u}\u2500{color}{network_dict.pop('name')}")
 
-    obj_keys = sorted(obj)
+    obj_keys = sorted(network_dict)
     if "id" in obj_keys:
         obj_keys.remove("id")
         obj_keys.insert(0, "id")
 
     for key in obj_keys:
-        value = obj[key]
+        value = network_dict[key]
         u = "\u2514" if key == obj_keys[-1] else "\u251c"
 
         if indent:

--- a/brownie/_cli/networks.py
+++ b/brownie/_cli/networks.py
@@ -39,7 +39,7 @@ as well as possible data fields when declaring new networks."""
 
 DEV_REQUIRED = ("id", "host", "cmd", "cmd_settings")
 PROD_REQUIRED = ("id", "host", "chainid")
-OPTIONAL = ("name",)
+OPTIONAL = ("name", "explorer")
 
 DEV_CMD_SETTINGS = (
     "port",

--- a/brownie/data/default-config.yaml
+++ b/brownie/data/default-config.yaml
@@ -5,6 +5,8 @@
 # a project. Missing or malformed fields in this file could break Brownie.
 # https://eth-brownie.readthedocs.io/en/stable/config.html
 
+dependencies: null
+
 networks:
     default: development
     development:
@@ -32,6 +34,5 @@ hypothesis:
     max_examples: 50
     stateful_step_count: 10
 
+autofetch_sources: false
 show_colors: true
-
-dependencies: null

--- a/brownie/data/network-config.yaml
+++ b/brownie/data/network-config.yaml
@@ -5,32 +5,39 @@ live:
         chainid: 1
         id: mainnet
         host: https://mainnet.infura.io/v3/$WEB3_INFURA_PROJECT_ID
+        explorer: https://api.etherscan.io/api
       - name: Ropsten (Infura)
         chainid: 3
         id: ropsten
         host: https://ropsten.infura.io/v3/$WEB3_INFURA_PROJECT_ID
+        explorer: https://api-ropsten.etherscan.io/api
       - name: Rinkeby (Infura)
         chainid: 4
         id: rinkeby
         host: https://rinkeby.infura.io/v3/$WEB3_INFURA_PROJECT_ID
+        explorer: https://api-rinkeby.etherscan.io/api
       - name: Goerli (Infura)
         chainid: 5
         id: goerli
         host: https://goerli.infura.io/v3/$WEB3_INFURA_PROJECT_ID
+        explorer: https://api-goerli.etherscan.io/api
       - name: Kovan (Infura)
         chainid: 42
         id: kovan
         host: https://kovan.infura.io/v3/$WEB3_INFURA_PROJECT_ID
+        explorer: https://api-kovan.etherscan.io/api
   - name: Ethereum Classic
     networks:
       - name: Mainnet
         chainid: 61
         id: etc
         host: https://www.ethercluster.com/etc
+        explorer:  https://blockscout.com/etc/mainnet/api
       - name: Kotti
         chainid: 6
         id: kotti
         host: https://www.ethercluster.com/kotti
+        explorer: https://blockscout.com/etc/kotti/api
 
 development:
   - name: Ganache-CLI

--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -326,9 +326,28 @@ class _DeployedContractBase(_ContractBase):
 
 
 class Contract(_DeployedContractBase):
+    """
+    Object to interact with a deployed contract outside of a project.
+    """
+
     def __init__(
         self, address_or_alias: str, *args: Any, owner: Optional[AccountsType] = None, **kwargs: Any
     ) -> None:
+        """
+        Recreate a `Contract` object from the local database.
+
+        The init method is used to access deployments that have already previously
+        been stored locally. For new deployments use `from_abi`, `from_ethpm` or
+        `from_etherscan`.
+
+        Arguments
+        ---------
+        address_or_alias : str
+            Address or user-defined alias of the deployment.
+        owner : Account, optional
+            Contract owner. If set, transactions without a `from` field
+            will be performed using this account.
+        """
         if args or kwargs:
             warnings.warn(
                 "Initializing `Contract` in this manner is deprecated."
@@ -400,6 +419,21 @@ class Contract(_DeployedContractBase):
     def from_abi(
         cls, name: str, address: str, abi: Dict, owner: Optional[AccountsType] = None
     ) -> "Contract":
+        """
+        Create a new `Contract` object from an ABI.
+
+        Arguments
+        ---------
+        name : str
+            Name of the contract.
+        address : str
+            Address where the contract is deployed.
+        abi : dict
+            Contract ABI, given as a dictionary.
+        owner : Account, optional
+            Contract owner. If set, transactions without a `from` field
+            will be performed using this account.
+        """
         address = _resolve_address(address)
         build = {"abi": abi, "address": address, "contractName": name, "type": "contract"}
 
@@ -417,6 +451,23 @@ class Contract(_DeployedContractBase):
         address: Optional[str] = None,
         owner: Optional[AccountsType] = None,
     ) -> "Contract":
+        """
+        Create a new `Contract` object from an ethPM manifest.
+
+        Arguments
+        ---------
+        name : str
+            Name of the contract.
+        manifest_uri : str
+            erc1319 registry URI where the manifest is located
+        address : str optional
+            Address where the contract is deployed. Only required if the
+            manifest contains more than one deployment with the given name
+            on the active chain.
+        owner : Account, optional
+            Contract owner. If set, transactions without a `from` field
+            will be performed using this account.
+        """
         manifest = ethpm.get_manifest(manifest_uri)
 
         if address is None:
@@ -450,6 +501,17 @@ class Contract(_DeployedContractBase):
 
     @classmethod
     def from_explorer(cls, address: str, owner: Optional[AccountsType] = None) -> "Contract":
+        """
+        Create a new `Contract` object with source code queried from a block explorer.
+
+        Arguments
+        ---------
+        address : str
+            Address where the contract is deployed.
+        owner : Account, optional
+            Contract owner. If set, transactions without a `from` field
+            will be performed using this account.
+        """
         url = CONFIG.active_network.get("explorer")
         if url is None:
             raise ValueError("Explorer API not set for this network")
@@ -513,6 +575,15 @@ class Contract(_DeployedContractBase):
         return self
 
     def set_alias(self, alias: Optional[str]) -> None:
+        """
+        Apply a unique alias this object. The alias can be used to restore the
+        object in future sessions.
+
+        Arguments
+        ---------
+        alias: str | None
+            An alias to apply. If `None`, any existing alias is removed.
+        """
         if CONFIG.network_type != "live":
             raise ValueError("Cannot set alias outside of live environment")
 

--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -380,6 +380,19 @@ class Contract(_DeployedContractBase):
         _DeployedContractBase.__init__(self, address, owner, None)
         _add_contract(self)
 
+    @classmethod
+    def from_abi(
+        cls, name: str, address: str, abi: Dict, owner: Optional[AccountsType] = None
+    ) -> "Contract":
+        address = _resolve_address(address)
+        build = {"abi": abi, "address": address, "contractName": name, "type": "contract"}
+
+        self = cls.__new__(cls)
+        _ContractBase.__init__(self, None, build, {})  # type: ignore
+        _DeployedContractBase.__init__(self, address, owner, None)
+        _add_contract(self)
+        return self
+
 
 class ProjectContract(_DeployedContractBase):
 

--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -62,7 +62,7 @@ class _ContractBase:
         """
         Display NatSpec documentation for this contract.
         """
-        if "natspec" in self._build:
+        if self._build.get("natspec"):
             _print_natspec(self._build["natspec"])
 
     def get_method(self, calldata: str) -> Optional[str]:
@@ -254,7 +254,7 @@ class _DeployedContractBase(_ContractBase):
             name = f"{self._name}.{abi['name']}"
             sig = build_function_signature(abi)
             natspec: Dict = {}
-            if "natspec" in self._build:
+            if self._build.get("natspec"):
                 natspec = self._build["natspec"]["methods"].get(sig, {})
 
             if fn_names.count(abi["name"]) == 1:

--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -37,7 +37,7 @@ from brownie.utils import color
 from . import accounts, rpc
 from .event import _get_topics
 from .rpc import _revert_register
-from .state import _add_contract, _find_contract, _get_deployment, _remove_contract
+from .state import _add_contract, _add_deployment, _find_contract, _get_deployment, _remove_contract
 from .web3 import _resolve_address, web3
 
 __tracebackhide__ = True
@@ -147,7 +147,7 @@ class ContractContainer(_ContractBase):
             owner: Default Account instance to send contract transactions from.
             tx: Transaction ID of the contract creation."""
         contract = _find_contract(address)
-        if contract:
+        if isinstance(contract, ProjectContract):
             if contract._name == self._name and contract._project == self._project:
                 return contract
             raise ContractExists(
@@ -162,6 +162,7 @@ class ContractContainer(_ContractBase):
 
         contract._save_deployment()
         _add_contract(contract)
+        _add_deployment(contract)
         self._contracts.append(contract)
         return contract
 
@@ -383,7 +384,6 @@ class Contract(_DeployedContractBase):
         build = {"abi": abi, "contractName": name, "type": "contract"}
         _ContractBase.__init__(self, None, build, {})  # type: ignore
         _DeployedContractBase.__init__(self, address, owner, None)
-        _add_contract(self)
 
     @classmethod
     def from_abi(
@@ -395,7 +395,7 @@ class Contract(_DeployedContractBase):
         self = cls.__new__(cls)
         _ContractBase.__init__(self, None, build, {})  # type: ignore
         _DeployedContractBase.__init__(self, address, owner, None)
-        _add_contract(self)
+        _add_deployment(self)
         return self
 
     @classmethod
@@ -434,7 +434,7 @@ class Contract(_DeployedContractBase):
         self = cls.__new__(cls)
         _ContractBase.__init__(self, None, build, manifest["sources"])  # type: ignore
         _DeployedContractBase.__init__(self, address, owner)
-        _add_contract(self)
+        _add_deployment(self)
         return self
 
     @classmethod
@@ -498,7 +498,7 @@ class Contract(_DeployedContractBase):
         self = cls.__new__(cls)
         _ContractBase.__init__(self, None, build, sources)  # type: ignore
         _DeployedContractBase.__init__(self, address, owner)
-        _add_contract(self)
+        _add_deployment(self)
         return self
 
 

--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -501,6 +501,26 @@ class Contract(_DeployedContractBase):
         _add_deployment(self)
         return self
 
+    def set_alias(self, alias: Optional[str]) -> None:
+        if CONFIG.network_type != "live":
+            raise ValueError("Cannot set alias outside of live environment")
+
+        if alias is not None:
+            if "." in alias or alias.lower().startswith("0x"):
+                raise ValueError("Invalid alias")
+            build, _ = _get_deployment(alias=alias)
+            if build is not None:
+                if build["address"] != self.address:
+                    raise ValueError("Alias is already in use on another contract")
+                return
+
+        _add_deployment(self, alias)
+        self._build["alias"] = alias
+
+    @property
+    def alias(self) -> Optional[str]:
+        return self._build.get("alias")
+
 
 class ProjectContract(_DeployedContractBase):
 

--- a/brownie/network/state.py
+++ b/brownie/network/state.py
@@ -118,8 +118,6 @@ def _get_current_dependencies() -> List:
 
 def _add_contract(contract: Any) -> None:
     _contract_map[contract.address] = contract
-    if CONFIG.network_type == "live":
-        _add_deployment(contract)
 
 
 def _remove_contract(contract: Any) -> None:
@@ -158,6 +156,9 @@ def _get_deployment(
 
 
 def _add_deployment(contract: Any) -> None:
+    if CONFIG.network_type != "live":
+        return
+
     address = _resolve_address(contract.address)
     name = f"chain{CONFIG.active_network['chainid']}"
 

--- a/brownie/network/state.py
+++ b/brownie/network/state.py
@@ -155,7 +155,7 @@ def _get_deployment(
     return build_json, sources
 
 
-def _add_deployment(contract: Any) -> None:
+def _add_deployment(contract: Any, alias: Optional[str] = None) -> None:
     if CONFIG.network_type != "live":
         return
 
@@ -175,4 +175,4 @@ def _add_deployment(contract: Any) -> None:
         all_sources[key] = [hash_, path]
 
     values = [contract._build.get(i) for i in DEPLOYMENT_KEYS]
-    cur.insert(name, address, "", all_sources, *values)
+    cur.insert(name, address, alias, all_sources, *values)

--- a/brownie/project/build.py
+++ b/brownie/project/build.py
@@ -4,29 +4,32 @@ from typing import Dict, ItemsView, List, Optional, Tuple, Union
 
 from .sources import Sources, highlight_source
 
-BUILD_KEYS = [
+DEPLOYMENT_KEYS = [
     "abi",
-    "allSourcePaths",
     "ast",
     "bytecode",
-    "bytecodeSha1",
     "compiler",
     "contractName",
-    "coverageMap",
     "deployedBytecode",
     "deployedSourceMap",
-    "dependencies",
     "language",
     "natspec",
-    "offset",
     "opcodes",
     "pcMap",
-    "sha1",
-    "source",
     "sourceMap",
-    "sourcePath",
     "type",
 ]
+
+BUILD_KEYS = [
+    "allSourcePaths",
+    "bytecodeSha1",
+    "coverageMap",
+    "dependencies",
+    "offset",
+    "sha1",
+    "source",
+    "sourcePath",
+] + DEPLOYMENT_KEYS
 
 _revert_map: Dict = {}
 

--- a/brownie/project/ethpm.py
+++ b/brownie/project/ethpm.py
@@ -162,6 +162,7 @@ def process_manifest(manifest: Dict, uri: Optional[str] = None) -> Dict:
                     "source_path": build["sourcePath"],
                     "all_source_paths": sorted(build["allSourcePaths"].values()),
                     "compiler": build["compiler"],
+                    "natspec": build["natspec"],
                 }
             )
 

--- a/brownie/utils/sql.py
+++ b/brownie/utils/sql.py
@@ -1,0 +1,36 @@
+#!/usr/bin/python3
+
+import json
+import sqlite3
+
+
+class Cursor:
+    def __init__(self, filename):
+        self.connect(filename)
+
+    def connect(self, filename):
+        self._db = sqlite3.connect(str(filename), isolation_level=None)
+        self._cur = self._db.cursor()
+
+    def insert(self, table, *values):
+        values = [json.dumps(i) if isinstance(i, (dict, list)) else i for i in values]
+        self._cur.execute(
+            f"INSERT OR REPLACE INTO {table} VALUES ({','.join('?'*len(values))})", values
+        )
+
+    def execute(self, cmd, *args):
+        self._cur.execute(cmd, *args)
+
+    def fetchone(self, cmd, *args):
+        self._cur.execute(cmd, *args)
+        result = self._cur.fetchone()
+        if result:
+            return tuple(json.loads(i) if str(i)[:1] in ("[", "{") else i for i in result)
+
+    def fetchall(self, cmd, *args):
+        self._cur.execute(cmd, *args)
+        return self._cur.fetchall()
+
+    def close(self):
+        self._cur.close()
+        self._db.close()

--- a/docs/api-brownie.rst
+++ b/docs/api-brownie.rst
@@ -13,7 +13,7 @@ The ``brownie`` package is the main package containing all of Brownie's function
 
     >>> from brownie import *
     >>> dir()
-    ['Fixed', 'Wei', 'accounts', 'alert', 'compile_source', 'config', 'history', 'network', 'project', 'rpc', 'run', 'web3']
+    ['Contract', 'Fixed', 'Wei', 'accounts', 'alert', 'compile_source', 'config', 'history', 'network', 'project', 'rpc', 'run', 'web3']
 
 ``brownie.exceptions``
 ======================

--- a/docs/compile.rst
+++ b/docs/compile.rst
@@ -84,7 +84,16 @@ Compiler Optimization
 
 Compiler optimization is enabled by default. Coverage evaluation was designed using optimized contracts, there is no need to disable it during testing.
 
-Values given under ``compiler.solc.optimizer`` in the project :ref:`configuration file <config>` are passed to the compiler with no reformatting. This way you can enable specific settings such as the YUL optimizer.
+Values given under ``compiler.solc.optimizer`` in the project :ref:`configuration file <config>` are passed directly to the compiler. This way you can modify specific optimizer settings. For example, to enable common subexpression elimination and the YUL optimizer:
+
+.. code-block::  yaml
+
+    compiler:
+        solc:
+            optimizer:
+                details:
+                    cse: true
+                    yul: true
 
 See the Solidity documentation for information on the `optimizer <https://solidity.readthedocs.io/en/latest/using-the-compiler.html#input-description>`_ and it's `available settings <https://solidity.readthedocs.io/en/latest/using-the-compiler.html#input-description>`_.
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -121,6 +121,12 @@ Default settings for :ref:`property-based<hypothesis>` and :ref:`stateful<hypoth
 Other Settings
 --------------
 
+.. py:attribute:: autofetch_sources
+
+    If enabled, Brownie will always attempt to fetch source code for unknown addresses using :func:`Contract.from_explorer <Contract.from_explorer>`.
+
+    default value: ``false``
+
 .. py:attribute:: show_colors
 
     Enable or disable colorful console output.

--- a/docs/core-contracts.rst
+++ b/docs/core-contracts.rst
@@ -37,7 +37,7 @@ It must be called with the contract constructor arguments, and a dictionary of :
     <Token Contract object '0x5419710735c2D6c3e4db8F30EF2d361F70a4b380'>
 
 
-Calling :func:`ContractContainer.deploy <ContractContainer.deploy>` returns a :func:`Contract <brownie.network.contract.ProjectContract>` object. The returned object is also appended to the :func:`ContractContainer <brownie.network.contract.ContractContainer>`.
+Calling :func:`ContractContainer.deploy <ContractContainer.deploy>` returns a :func:`ProjectContract <brownie.network.contract.ProjectContract>` object. The returned object is also appended to the :func:`ContractContainer <brownie.network.contract.ContractContainer>`.
 
 .. code-block:: python
 
@@ -90,7 +90,7 @@ You may call or send a transaction to any public function within a contract. How
     * In Solidity, callable methods are labelled as `view <https://solidity.readthedocs.io/en/v0.6.0/contracts.html#view-functions>`_ or `pure <https://solidity.readthedocs.io/en/v0.6.0/contracts.html#pure-functions>`_
     * In Vyper, callable methods include the `@constant <https://vyper.readthedocs.io/en/latest/structure-of-a-contract.html#decorators>`_ decorator.
 
-All public contract methods are available from the :func:`Contract <brownie.network.contract.ProjectContract>` object via class methods of the same name.
+All public contract methods are available from the :func:`ProjectContract <brownie.network.contract.ProjectContract>` object via class methods of the same name.
 
 .. code-block:: python
 
@@ -172,15 +172,40 @@ If you wish to access the method via a transaction you can use :func:`ContractCa
     >>> tx.return_value
     1000000000000000000000
 
+.. _core-contracts-live:
+
 Contracts Outside of your Project
 =================================
 
-It is also possible to create a :func:`Contract <brownie.network.contract.Contract>` object using only an `ABI <https://solidity.readthedocs.io/en/latest/abi-spec.html#json>`_. In this way you can interact with already deployed contracts that are not a part of your core project.
+When working in a :ref:`live environment <network-management>`, you can create :func:`Contract <brownie.network.contract.Contract>` objects to interact with already-deployed contracts.
 
-To create a :func:`Contract <brownie.network.contract.Contract>` from an ABI:
+New :func:`Contract <brownie.network.contract.Contract>` objects are created using one of three :ref:`class methods <api-network-contract-classmethods>`. Options for creation include:
+
+    * Fetching verified source code from a block explorer, such as `Etherscan <https://etherscan.io/>`_
+    * Providing an `ABI <https://solidity.readthedocs.io/en/latest/abi-spec.html#json>`_ and an address
+    * Fetching the information from an ethPM registry
+
+For example, use :func:`Contract.from_explorer <Contract.from_explorer>` to create an object by querying Etherscan:
 
 .. code-block:: python
 
-    >>> from brownie import Contract
-    >>> Contract("Token", "0x79447c97b6543F6eFBC91613C655977806CB18b0", abi)
-    <Token Contract object '0x79447c97b6543F6eFBC91613C655977806CB18b0'>
+    >>> Contract.from_explorer("0x6b175474e89094c44da98b954eedeac495271d0f")
+    Fetching source of 0x6B175474E89094C44Da98b954EedeAC495271d0F from api.etherscan.io...
+    <Dai Contract '0x6B175474E89094C44Da98b954EedeAC495271d0F'>
+
+The data used to create :func:`Contract <brownie.network.contract.Contract>` objects is stored in a local database and persists between sessions. After the initial creation via a :ref:`class method <api-network-contract-classmethods>`, you can recreate an object by initializing :func:`Contract <brownie.network.contract.Contract>` with an address:
+
+.. code-block:: python
+
+    >>> Contract("0x6b175474e89094c44da98b954eedeac495271d0f")
+    <Dai Contract '0x6B175474E89094C44Da98b954EedeAC495271d0F'>
+
+Alternatively, :func:`Contract.set_alias <Contract.set_alias>` allows you to create an alias for quicker access. Aliases also persist between sessions.
+
+.. code-block:: python
+
+    >>> contract = Contract("0x6b175474e89094c44da98b954eedeac495271d0f")
+    >>> contract.set_alias('dai')
+
+    >>> Contract('dai')
+    <Dai Contract '0x6B175474E89094C44Da98b954EedeAC495271d0F'>

--- a/docs/deploy.rst
+++ b/docs/deploy.rst
@@ -36,22 +36,22 @@ Here is an small example script that unlocks a local account and uses it to depl
 Running your Deployment Script
 ==============================
 
-In order to execute your script on a non-local network, you must include the ``--network`` flag in the command line. For example, to connect to the ropsten network and run ``scripts/deploy.py``:
+In order to execute your script in a live environment, you must include the ``--network`` flag in the command line. For example, to connect to the ropsten network and run ``scripts/deploy.py``:
 
 ::
 
     $ brownie run deploy.py --network ropsten
 
-Remember that transactions are not confirmed immediately on non-local networks. You will see a notification on the status of each transaction, however the script will take some time to complete.
+Remember that transactions are not confirmed immediately on live networks. You will see a notification on the status of each transaction, however the script will take some time to complete.
 
-See the documentation on :ref:`using non-local networks<nonlocal-networks>` for more information on how to define and connect to other networks.
+See the documentation on :ref:`network management<network-management>` for more information on how to define and connect to live networks.
 
 .. _persistence:
 
 Interacting with Deployed Contracts
 ===================================
 
-Brownie saves information about contract deployments on non-local networks. Once a contract has been deployed, the generated :func:`Contract <brownie.network.contract.ProjectContract>` instance will still be available the next time you load Brownie.
+Brownie saves information about contract deployments on live networks. Once a contract has been deployed, the generated :func:`ProjectContract <brownie.network.contract.ProjectContract>` instance will still be available in future Brownie sessions.
 
 The following actions will NOT remove locally stored deployment data:
 
@@ -60,10 +60,10 @@ The following actions will NOT remove locally stored deployment data:
     * Exiting and reloading Brownie
     * Modifying a contract's source code - Brownie still retains the source for the deployed version
 
-The following actions WILL remove locally stored deployment data:
+The following actions WILL remove locally stored deployment data within your project:
 
-    * Calling :func:`ContractContainer.remove <ContractContainer.remove>` will erase deployment information for the removed :func:`Contract <brownie.network.contract.ProjectContract>` instances.
+    * Calling :func:`ContractContainer.remove <ContractContainer.remove>` will erase deployment information for the removed :func:`ProjectContract <brownie.network.contract.ProjectContract>` instances.
     * Removing or renaming a contract source file within your project will cause Brownie to delete all deployment information for the removed contract.
     * Deleting the ``build/deployments/`` directory will erase all information about deployed contracts.
 
-To restore a deleted :func:`Contract <brownie.network.contract.ProjectContract>` instance, or generate one for a deployment that was handled outside of Brownie, use the :func:`ContractContainer.at <ContractContainer.at>` method.
+To restore a deleted :func:`ProjectContract <brownie.network.contract.ProjectContract>` instance, or generate one for a deployment that was handled outside of Brownie, use the :func:`ContractContainer.at <ContractContainer.at>` method.

--- a/docs/network-management.rst
+++ b/docs/network-management.rst
@@ -1,4 +1,4 @@
-.. _nonlocal-networks:
+.. _network-management:
 
 ==================
 Network Management
@@ -56,18 +56,33 @@ To add a new network:
 
     $ brownie networks add [environment] [id] host=[host] [KEY=VALUE, ...]
 
-The following fields may be used for both live and development networks:
+When declaring a new network, the following fields must always be included:
 
     * ``environment``: the category that the network should be placed in, e.g. "Ethereum", "Ethereum Classic", or "Development"
     * ``id``: a unique identifier for the network, e.g. "mainnet"
     * ``host``: the address of the node to connect to, e.g. ``https://mainnet.infura.io/v3/1234567890abcdef``
-    * ``name`` (optional): A longer name to use for the network. If not given, ``id`` is used.
 
-The following fields are required for live networks:
+The following fields are optional:
 
-    * ``chainid``: The chain ID for a network. Live networks with the same chain ID share data about contract deployments. See `chainid.network <https://chainid.network/>`_ for a list of chain IDs.
+    * ``name`` A longer name to use for the network. If not given, ``id`` is used.
 
-The following fields are required for development networks:
+There are additional required and optional fields that are dependent on the type of network.
+
+Live Networks
+*************
+
+Live networks **must** include the following fields:
+
+    * ``chainid``: The chain ID for a network. Live networks with the same chain ID share local data about :ref:`contract deployments <core-contracts-live>`. See `chainid.network <https://chainid.network/>`_ for a list of chain IDs.
+
+The following fields are optional for live networks:
+
+    * ``explorer``: API url used by :func:`Contract.from_explorer <Contract.from_explorer>` to fetch source code. If this field is not given, you will not be able to fetch source code when using this network.
+
+Development Networks
+********************
+
+Development networks **must** include the following fields:
 
     * ``cmd``: The command used to launch the local RPC client, e.g. ``ganache-cli``.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -121,6 +121,12 @@ def xdist_id(worker_id):
 def _base_config(tmp_path_factory, xdist_id):
     brownie._config.DATA_FOLDER = tmp_path_factory.mktemp(f"data-{xdist_id}")
     brownie._config._make_data_folders(brownie._config.DATA_FOLDER)
+
+    cur = brownie.network.state.cur
+    cur.close()
+    cur.connect(brownie._config.DATA_FOLDER.joinpath("pytest.db"))
+    cur.execute("CREATE TABLE IF NOT EXISTS sources (hash PRIMARY KEY, source)")
+
     if xdist_id:
         port = 8545 + xdist_id
         brownie._config.CONFIG.networks["development"]["cmd_settings"]["port"] = port

--- a/tests/network/contract/test_contract.py
+++ b/tests/network/contract/test_contract.py
@@ -49,7 +49,7 @@ def test_namespace_collision(tester, build):
         }
     )
     with pytest.raises(AttributeError):
-        Contract(None, tester.address, build["abi"])
+        Contract.from_abi(None, tester.address, build["abi"])
 
 
 def test_overloaded(testproject, tester, build):
@@ -69,7 +69,7 @@ def test_overloaded(testproject, tester, build):
         }
     )
     del testproject.BrownieTester[0]
-    c = Contract(None, tester.address, build["abi"])
+    c = Contract.from_abi(None, tester.address, build["abi"])
     fn = c.revertStrings
     assert type(fn) == OverloadedMethod
     assert len(fn) == 2
@@ -102,7 +102,7 @@ def test_comparison(testproject, tester):
     del testproject.BrownieTester[0]
     assert tester != 123
     assert tester == str(tester.address)
-    assert tester == Contract("BrownieTester", tester.address, tester.abi)
+    assert tester == Contract.from_abi("BrownieTester", tester.address, tester.abi)
     repr(tester)
 
 
@@ -113,24 +113,145 @@ def test_revert_not_found(tester, rpc):
 
 
 def test_contractabi_replace_contract(testproject, tester):
-    Contract("BrownieTester", tester.address, tester.abi)
+    Contract.from_abi("BrownieTester", tester.address, tester.abi)
     del testproject.BrownieTester[0]
-    Contract("BrownieTester", tester.address, tester.abi)
-    Contract("BrownieTester", tester.address, tester.abi)
+    Contract.from_abi("BrownieTester", tester.address, tester.abi)
+    Contract.from_abi("BrownieTester", tester.address, tester.abi)
 
 
 def test_contract_from_ethpm(ipfs_mock, network):
     network.connect("ropsten")
-    Contract("ComplexNothing", manifest_uri="ipfs://testipfs-complex")
+    Contract.from_ethpm("ComplexNothing", manifest_uri="ipfs://testipfs-complex")
 
 
 def test_contract_from_ethpm_multiple_deployments(ipfs_mock, network):
     network.connect("mainnet")
     with pytest.raises(ValueError):
-        Contract("ComplexNothing", manifest_uri="ipfs://testipfs-complex")
+        Contract.from_ethpm("ComplexNothing", manifest_uri="ipfs://testipfs-complex")
 
 
 def test_contract_from_ethpm_no_deployments(ipfs_mock, network):
     network.connect("kovan")
     with pytest.raises(ContractNotFound):
-        Contract("ComplexNothing", manifest_uri="ipfs://testipfs-complex")
+        Contract.from_ethpm("ComplexNothing", manifest_uri="ipfs://testipfs-complex")
+
+
+def test_deprecated_init_abi(tester):
+    old = Contract("BrownieTester", tester.address, tester.abi)
+    assert old == Contract.from_abi("BrownieTester", tester.address, tester.abi)
+
+
+def test_deprecated_init_ethpm(ipfs_mock, network):
+    network.connect("ropsten")
+    old = Contract("ComplexNothing", manifest_uri="ipfs://testipfs-complex")
+
+    assert old == Contract.from_ethpm("ComplexNothing", manifest_uri="ipfs://testipfs-complex")
+
+
+def test_from_explorer(network):
+    network.connect("mainnet")
+    contract = Contract.from_explorer("0x2af5d2ad76741191d15dfe7bf6ac92d4bd912ca3")
+
+    assert contract._name == "LEO"
+    assert "pcMap" in contract._build
+    assert len(contract._sources) == 1
+
+
+def test_from_explorer_pre_422(network):
+    network.connect("mainnet")
+    contract = Contract.from_explorer("0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2")
+
+    assert contract._name == "DSToken"
+    assert "pcMap" not in contract._build
+
+
+def test_from_explorer_vyper(network):
+    network.connect("mainnet")
+    contract = Contract.from_explorer("0x2157a7894439191e520825fe9399ab8655e0f708")
+
+    assert contract._name == "Vyper_contract"
+    assert "pcMap" not in contract._build
+
+
+def test_from_explorer_unverified(network):
+    network.connect("mainnet")
+    with pytest.raises(ValueError):
+        Contract.from_explorer("0x0000000000000000000000000000000000000000")
+
+
+def test_from_explorer_etc(network):
+    network.connect("etc")
+    contract = Contract.from_explorer("0x085b0fdf115aa9e16ae1bddd396ce1f993c52220")
+
+    assert contract._name == "ONEX"
+
+
+def test_retrieve_existing(network):
+    network.connect("mainnet")
+    new = Contract.from_explorer("0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2")
+
+    existing = Contract("0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2")
+    assert new == existing
+
+
+def test_existing_different_chains(network):
+    network.connect("mainnet")
+    Contract.from_explorer("0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2")
+
+    network.disconnect()
+    network.connect("ropsten")
+    with pytest.raises(ValueError):
+        Contract("0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2")
+
+
+def test_alias(network):
+    network.connect("mainnet")
+    contract = Contract.from_explorer("0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2")
+
+    contract.set_alias("testalias")
+
+    assert contract.alias == "testalias"
+    assert Contract("testalias") == contract
+
+    contract.set_alias(None)
+
+    assert contract.alias is None
+    with pytest.raises(ValueError):
+        Contract("testalias")
+
+
+def test_alias_not_exists(network):
+    network.connect("mainnet")
+
+    with pytest.raises(ValueError):
+        Contract("doesnotexist")
+
+
+def test_duplicate_alias(network):
+    network.connect("mainnet")
+    foo = Contract.from_explorer("0x2af5d2ad76741191d15dfe7bf6ac92d4bd912ca3")
+    bar = Contract.from_explorer("0x2157a7894439191e520825fe9399ab8655e0f708")
+
+    foo.set_alias("foo")
+    with pytest.raises(ValueError):
+        bar.set_alias("foo")
+
+    bar.set_alias("bar")
+    foo.set_alias(None)
+    bar.set_alias("foo")
+
+
+def test_alias_in_development(tester):
+    contract = Contract.from_abi("BrownieTester", tester.address, tester.abi)
+
+    with pytest.raises(ValueError):
+        contract.set_alias("testalias")
+
+
+def test_autofetch(network, config):
+    network.connect("mainnet")
+    with pytest.raises(ValueError):
+        Contract("0xdAC17F958D2ee523a2206206994597C13D831ec7")
+
+    config.settings["autofetch_sources"] = True
+    Contract("0xdAC17F958D2ee523a2206206994597C13D831ec7")

--- a/tests/network/contract/test_ens_contract.py
+++ b/tests/network/contract/test_ens_contract.py
@@ -9,7 +9,7 @@ from brownie.network.contract import Contract
 
 def test_lookup(network):
     network.connect("mainnet")
-    c = Contract("Test", "ens.snakecharmers.eth", [])
+    c = Contract.from_abi("Test", "ens.snakecharmers.eth", [])
     assert c == "0x808B53bF4D70A24bA5cb720D37A4835621A9df00"
     assert c == "ens.snakecharmers.eth"
 
@@ -17,10 +17,10 @@ def test_lookup(network):
 def test_invalid(network):
     network.connect("mainnet")
     with pytest.raises(InvalidName):
-        Contract("Test", "this-is-not-an-ENS-address,isit?.eth", [])
+        Contract.from_abi("Test", "this-is-not-an-ENS-address,isit?.eth", [])
 
 
 def test_unset(network):
     network.connect("mainnet")
     with pytest.raises(UnsetENSName):
-        Contract("Test", "pleasedonot.buythisoryouwill.breakmytests.eth", [])
+        Contract.from_abi("Test", "pleasedonot.buythisoryouwill.breakmytests.eth", [])

--- a/tests/network/transaction/test_trace.py
+++ b/tests/network/transaction/test_trace.py
@@ -246,5 +246,5 @@ def test_unknown_contract(ExternalCallTester, accounts, tester, ext_tester):
 def test_contractabi(ExternalCallTester, accounts, tester, ext_tester):
     tx = tester.makeExternalCall(ext_tester, 4)
     del ExternalCallTester[0]
-    ext_tester = Contract("ExternalTesterABI", ext_tester.address, ext_tester.abi)
+    ext_tester = Contract.from_abi("ExternalTesterABI", ext_tester.address, ext_tester.abi)
     tx.call_trace()

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ envlist =
 
 [testenv]
 passenv =
+    ETHERSCAN_TOKEN
     GITHUB_TOKEN
     WEB3_INFURA_PROJECT_ID
 envdir =


### PR DESCRIPTION
### What I did
* Deprecate existing `Contract.__init__` functionality in favor of class methods:
  * `from_abi`: create manually from an ABI
  * `from_ethpm`: create from an ethpm manifest
  * `from_explorer`: create by querying etherscan (!)
* Store persistent data for live networks in an sqlite database at `~/.brownie/deployments.db`
* Allow aliasing and restoring persistent data between sessions via `Contract.__init__`
