### PR TITLE
fix: colorful output on skipped tests without xdist

### DIFF
--- a/brownie/test/managers/runner.py
+++ b/brownie/test/managers/runner.py
@@ -205,6 +205,8 @@ class PytestBrownieRunner(PytestBrownieBase):
         if self.printer and report.when == "call":
             self.printer.finish(report.nodeid)
 
+        return super().pytest_report_teststatus(report)
+
     def pytest_sessionfinish(self):
         self._sessionfinish("build/tests.json")
         if CONFIG.argv["gas"]:


### PR DESCRIPTION
### What I did
* fix: colorful output on skipped tests without xdist