### PR TITLE
Add note about where to run `brownie init`

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ python3 setup.py install
 
 ## Quick Usage
 
-To set up the default folder and file structure for Brownie, from your project's directory, use:
+To initialize a new Brownie project, start by creating a new folder. From within that folder, type:
 
 ```bash
 brownie init

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ python3 setup.py install
 
 ## Quick Usage
 
-To set up the default folder and file structure for Brownie use:
+To set up the default folder and file structure for Brownie, from your project's directory, use:
 
 ```bash
 brownie init


### PR DESCRIPTION
I just ran `brownie init` in my `~/src` directory thinking it would prompt for the name of the project and it ended up making the files where I ran the command. We should add a note that `init` should be run from inside the new project's directory.

I'm not sure the best way to word it though.

### What I did

Added a small change to the readme

### How I did it

N/A

### How to verify it

N/A

### Checklist

- [N/A] I have confirmed that my PR passes all linting checks
- [N/A] I have included test cases
- [N/A] I have updated the documentation
- [N/A] I have added an entry to the changelog
