### PR TITLE
Adjust compile path

### DIFF
--- a/brownie/project/main.py
+++ b/brownie/project/main.py
@@ -72,7 +72,7 @@ class _ProjectBase:
         cwd = os.getcwd()
         if self._path is not None:
             _install_dependencies(self._path)
-            allow_paths = self._path.joinpath("contracts").as_posix()
+            allow_paths = self._path.as_posix()
             os.chdir(self._path)
 
         try:
@@ -84,7 +84,6 @@ class _ProjectBase:
                 evm_version=compiler_config["evm_version"],
                 silent=silent,
                 allow_paths=allow_paths,
-                interface_sources=self._sources.get_interface_sources(),
                 remappings=compiler_config["solc"].get("remappings", []),
                 optimizer=compiler_config["solc"].get("optimizer", None),
             )


### PR DESCRIPTION
### What I did
In the compiler, use the project root folder as `allow_paths` rather than `./contracts`. This allows interface imports without using the `interface_sources` kwarg. Re: conversation on Gitter, it also ensures a more expressive error message when an interface import will not work.

`interface_sources` was a solution added prior to the allowing path remappings. Now that it's possible to import from anywhere, `interface_sources` seems less useful and is a good candidate for removal in v2.0

### How to verify it
Run tests.
