### PR TITLE
fix: do not initialize new project within a non-empty directory

### DIFF
--- a/brownie/_cli/init.py
+++ b/brownie/_cli/init.py
@@ -10,7 +10,8 @@ Arguments:
   <path>                Path to initialize (default is the current path)
 
 Options:
-  --force -f            Allow init inside a project subfolder
+  --force -f            Allow initialization inside a directory that is not
+                        empty, or a subdirectory of an existing project
   --help -h             Display this message
 
 brownie init is used to create new brownie projects. It creates the default
@@ -22,10 +23,10 @@ interfaces/             Interface source code
 reports/                Report files for contract analysis
 scripts/                Scripts for deployment and interaction
 tests/                  Scripts for project testing
-brownie-config.yaml     Project configuration file"""
+"""
 
 
 def main():
     args = docopt(__doc__)
-    path = project.new(args["<path>"] or ".", args["--force"])
-    notify("SUCCESS", f"Brownie environment has been initiated at {path}")
+    path = project.new(args["<path>"] or ".", args["--force"], args["--force"])
+    notify("SUCCESS", f"A new Brownie project has been initialized at {path}")

--- a/tests/cli/test_cli_main.py
+++ b/tests/cli/test_cli_main.py
@@ -42,12 +42,12 @@ class CliTester:
 def test_cli_init(cli_tester):
     cli_tester.monkeypatch.setattr("brownie.project.new", cli_tester.mock_subroutines)
 
-    args = (".", False)
+    args = (".", False, False)
     kwargs = {}
     parameters = (args, kwargs)
     cli_tester.run_and_test_parameters("init", parameters)
 
-    args = ("test/path", True)
+    args = ("test/path", True, True)
     parameters = (args, kwargs)
     cli_tester.run_and_test_parameters("init test/path --force", parameters)
 


### PR DESCRIPTION
### What I did
Prevent `brownie init` from working in a directory that is not empty.

Related: #425 

### How I did it
Check that a directory is empty prior to init. From the CLI, you can use the `--force` flag to override the check.

### How to verify it
Run tests