### PR TITLE
chore: bump coveralls, tox, coverage versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,14 @@ jobs:
       python: 3.6
       dist: bionic
       install:
-        - python -m pip install coveralls==1.9.2 tox==3.14.3
+        - python -m pip install coveralls==2.0.0 tox==3.14.6
       script: tox -e lint
     - name: Documentation
       language: python
       python: 3.6
       dist: bionic
       install:
-        - python -m pip install coveralls==1.9.2 tox==3.14.3
+        - python -m pip install coveralls==2.0.0 tox==3.14.6
       script: tox -e doctest
     - name: EVM Tests - Python 3.7 (Linux)
       language: python
@@ -89,7 +89,7 @@ env:
 install:
   - python -m pip install --upgrade pip setuptools
   - npm -g install ganache-cli@6.8.2
-  - python -m pip install coveralls==1.9.2 tox==3.14.3
+  - python -m pip install coveralls==2.0.0 tox==3.14.6
 after_script: python -m coveralls
 notifications:
   email: false

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,6 @@
 black==19.10b0
 bumpversion==0.5.3
-coverage==4.5.4
-coveralls==1.9.2
+coverage==5.1
 flake8==3.7.9
 isort==4.3.21
 mypy==0.720
@@ -10,6 +9,6 @@ pytest-mock==2.0.0
 sphinx==2.4.0
 sphinx_rtd_theme==0.4.3
 pygments_lexer_solidity==0.4.0
-tox==3.14.3
+tox==3.14.6
 twine==3.1.1
 wheel==0.34.2

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ envdir =
     py37,evmtest: {toxinidir}/.tox/py37
     py38,plugintest: {toxinidir}/.tox/py38
 deps =
-    py{36,37,38},{pm,evm,plugin}test: coverage==4.5.4
+    py{36,37,38},{pm,evm,plugin}test: coverage==5.1
     py{36,37,38},{pm,evm,plugin}test: pytest==5.4.1
     py{36,37,38},{pm,evm,plugin}test: pytest-cov==2.8.1
     py{36,37,38},{pm,evm,plugin}test: pytest-mock==2.0.0


### PR DESCRIPTION
### What I did
Bump versions of `coveralls`, `coverage`, and `tox`.

Fixes #431 

### How I did it
Easily.

### How to verify it
Confirm that coverage is properly sent to coveralls after the tests finish. :crossed_fingers: 