### PR TITLE
Handle undecodable events

### DIFF
--- a/brownie/convert/normalize.py
+++ b/brownie/convert/normalize.py
@@ -29,6 +29,20 @@ def format_output(abi: Dict, outputs: Union[List, Tuple]) -> ReturnValue:
 
 def format_event(event: Dict) -> Any:
     # Format event data based on ABI types
+    if not event["decoded"]:
+        topics = [
+            {"type": "bytes32", "name": f"topic{c}", "value": i}
+            for c, i in enumerate(event.get("topics", []), start=1)
+        ]
+        event["data"] = topics + [
+            {"type": "bytes", "name": "data", "value": _format_single("bytes", event["data"])}
+        ]
+        if "anonymous" in event:
+            event["name"] = "(anonymous)"
+        else:
+            event["name"] = "(unknown)"
+        return event
+
     for e in [i for i in event["data"] if not i["decoded"]]:
         e["type"] = "bytes32"
         e["name"] += " (indexed)"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 colorama>=0.4.1;platform_system=='Windows'
 eth-abi==2.1.1
-eth-event>=0.2.2,<1.0.0
+eth-event>=1.0.0,<2.0.0
 eth-hash[pycryptodome]==0.2.0
 eth-utils==1.8.4
 hexbytes==0.2.0
@@ -8,7 +8,7 @@ hypothesis==5.8.0
 prompt-toolkit==3.0.5
 psutil>=5.7.0,<6.0.0
 py>=1.5.0
-py-solc-ast>=1.2.3,<2.0.0
+py-solc-ast>=1.2.4,<2.0.0
 py-solc-x>=0.8.1,<1.0.0
 pygments==2.6.1
 pytest==5.4.1


### PR DESCRIPTION
### What I did
Add support for events that cannot be decoded. 

Fixes #430 

### How I did it
Mostly handled upstream in  [`eth_event`](https://github.com/iamdefinitelyahuman/eth-event). Anonymous and undecoded events are now given the name `"(unknown)"` and undecoded topics are included as items within the event data.

### How to verify it
Run the tests.
