### PR TITLE
Mainnet fork

### DIFF
--- a/brownie/_config.py
+++ b/brownie/_config.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 
 import json
+import os
 import re
 import shutil
 import warnings
@@ -58,6 +59,17 @@ class ConfigContainer:
         network = self.networks[id_].copy()
         key = "development" if "cmd" in network else "live"
         network["settings"] = self.settings["networks"][key].copy()
+
+        if key == "development" and "fork" in network["cmd_settings"]:
+
+            fork = network["cmd_settings"]["fork"]
+            if fork in self.networks:
+                network["cmd_settings"]["fork"] = self.networks[fork]["host"]
+                network["chainid"] = self.networks[fork]["chainid"]
+                if "explorer" in self.networks[fork]:
+                    network["explorer"] = self.networks[fork]["explorer"]
+
+            network["cmd_settings"]["fork"] = os.path.expandvars(network["cmd_settings"]["fork"])
 
         self._active_network = network
         return network

--- a/brownie/data/network-config.yaml
+++ b/brownie/data/network-config.yaml
@@ -50,3 +50,14 @@ development:
       accounts: 10
       evm_version: istanbul
       mnemonic: brownie
+  - name: Ganache-CLI (Mainnet Fork)
+    id: mainnet-fork
+    cmd: ganache-cli
+    host: http://127.0.0.1
+    cmd_settings:
+      port: 8545
+      gas_limit: 10000000
+      accounts: 10
+      evm_version: istanbul
+      mnemonic: brownie
+      fork: mainnet

--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -168,8 +168,10 @@ class ContractContainer(_ContractBase):
 
         contract._save_deployment()
         _add_contract(contract)
-        _add_deployment(contract)
         self._contracts.append(contract)
+        if CONFIG.network_type == "live":
+            _add_deployment(contract)
+
         return contract
 
     def _add_from_tx(self, tx: TransactionReceiptType) -> None:

--- a/brownie/network/rpc.py
+++ b/brownie/network/rpc.py
@@ -272,7 +272,7 @@ class Rpc(metaclass=_Singleton):
         self._snapshot_id = None
         self._internal_id = None
         self._reset_id = self._revert(self._reset_id)
-        return "Block height reset to 0"
+        return f"Block height reset to {web3.eth.blockNumber}"
 
 
 # objects that will update whenever the RPC is reset or reverted must register

--- a/brownie/network/state.py
+++ b/brownie/network/state.py
@@ -151,6 +151,8 @@ def _get_deployment(
         for i in path_map.values()
     }
     build_json["allSourcePaths"] = {k: v[1] for k, v in path_map.items()}
+    if isinstance(build_json["pcMap"], dict):
+        build_json["pcMap"] = dict((int(k), v) for k, v in build_json["pcMap"].items())
 
     return build_json, sources
 

--- a/brownie/network/state.py
+++ b/brownie/network/state.py
@@ -100,7 +100,7 @@ def _find_contract(address: Any) -> Any:
     address = _resolve_address(address)
     if address in _contract_map:
         return _contract_map[address]
-    if CONFIG.network_type == "live":
+    if "chainid" in CONFIG.active_network:
         try:
             from brownie.network.contract import Contract
 
@@ -156,7 +156,7 @@ def _get_deployment(
 
 
 def _add_deployment(contract: Any, alias: Optional[str] = None) -> None:
-    if CONFIG.network_type != "live":
+    if "chainid" not in CONFIG.active_network:
         return
 
     address = _resolve_address(contract.address)

--- a/brownie/network/web3.py
+++ b/brownie/network/web3.py
@@ -43,7 +43,7 @@ class Web3(_Web3):
         if uri[:3] == "ws:":
             self.provider = WebsocketProvider(uri)
         elif uri[:4] == "http":
-            self.provider = HTTPProvider(uri)
+            self.provider = HTTPProvider(uri, {"timeout": 30})
         else:
             raise ValueError(
                 "Unknown URI - must be a path to an IPC socket, a websocket "

--- a/docs/core-contracts.rst
+++ b/docs/core-contracts.rst
@@ -177,7 +177,7 @@ If you wish to access the method via a transaction you can use :func:`ContractCa
 Contracts Outside of your Project
 =================================
 
-When working in a :ref:`live environment <network-management>`, you can create :func:`Contract <brownie.network.contract.Contract>` objects to interact with already-deployed contracts.
+When working in a :ref:`live environment <network-management-live>` or :ref:`forked development network <network-management-fork>`, you can create :func:`Contract <brownie.network.contract.Contract>` objects to interact with already-deployed contracts.
 
 New :func:`Contract <brownie.network.contract.Contract>` objects are created using one of three :ref:`class methods <api-network-contract-classmethods>`. Options for creation include:
 

--- a/docs/network-management.rst
+++ b/docs/network-management.rst
@@ -44,7 +44,8 @@ Type ``brownie networks list`` to view a list of existing networks:
       └─Kotti: kotti
 
     Development
-      └─Ganache-CLI: development
+      ├─Ganache-CLI: development
+      └─Ganache-CLI (Mainnet Fork): mainnet-fork
 
 
 Adding a New Network
@@ -93,7 +94,7 @@ The following optional fields may be given for development networks, which are p
     * ``accounts``: The number of funded, unlocked accounts. Default 10.
     * ``mnemonic``: A mnemonic to use when generating local accounts.
     * ``evm_version``: The EVM ruleset to use. Default is the most recent available.
-    * ``fork``: If given, the local client will fork from another currently running Ethereum client at a given block. Input should be the HTTP location and port of the other client, e.g. ``http://localhost:8545`` or optionally provide a block number ``http://localhost:8545@1599200``.
+    * ``fork``: If given, the local client will fork from another currently running Ethereum client. The value may be an HTTP location and port of the other client, e.g. ``http://localhost:8545``, or the ID of a production network, e.g. ``mainnet``. See :ref:`Using a Forked Development Network <network-management-fork>`.
 
 .. note::
 
@@ -147,6 +148,8 @@ To disconnect:
     >>> network.is_connected()
     False
 
+.. _network-management-live:
+
 Live Networks
 =============
 
@@ -189,3 +192,23 @@ To connect to Infura using Brownie, store your project ID as an environment vari
 ::
 
     $ export WEB3_INFURA_PROJECT_ID=YourProjectID
+
+.. _network-management-fork:
+
+Using a Forked Development Network
+==================================
+
+Ganache allows you create a development network by forking from an live network. This is useful for testing interactions between your project and other projects that are deployed on the main-net.
+
+Brownie's ``mainnet-fork`` network uses Infura to create a development network that forks from the main-net. To connect with the console:
+
+::
+
+    $ brownie console --network mainnet-fork
+
+In this mode, you can use :func:`Contract.from_explorer <Contract.from_explorer>` to fetch sources and interact with contracts on the network you have forked from.
+
+.. note::
+
+    Forking from Infura can be *very slow*. If you are using this mode
+    extensively, it may be useful to run your own Geth node.

--- a/tests/cli/test_cli_networks.py
+++ b/tests/cli/test_cli_networks.py
@@ -153,6 +153,7 @@ def test_delete_live():
 
 def test_delete_development():
     cli_networks._delete("development")
+    cli_networks._delete("mainnet-fork")
 
     with _get_data_folder().joinpath("network-config.yaml").open() as fp:
         networks = yaml.safe_load(fp)


### PR DESCRIPTION
### What I did
Simplify use of forked development network. Closes #435

### How I did it
* add `mainnet-fork` as development network, forking from Infura
* allow use of production network ID in `fork` field when declaring development network
* allow `Contract.from_explorer` when connected to forked development network
* test and debug querying deployments for transaction traces on mainnet
* add documentation (probably should be improved on in the future)

### How to verify it
Fork it.