### PR TITLE
fix: no-owner when making calls during coverage eval

### DIFF
--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -844,7 +844,7 @@ class ContractCall(_ContractMethod):
             return self.call(*args)
         rpc._internal_snap()
         args, tx = _get_tx(self._owner, args)
-        tx.update({"gas_price": 0, "from": self._owner})
+        tx.update({"gas_price": 0, "from": self._owner or accounts[0]})
         try:
             tx = self.transact(*args, tx)
             return tx.return_value

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,7 @@ ignore = E203,W503
 [tool:isort]
 force_grid_wrap = 0
 include_trailing_comma = True
+known_standard_library = tkinter
 known_first_party = brownie
 known_third_party = _pytest,ens,eth_abi,eth_event,eth_hash,eth_keys,eth_utils,ethpm,hexbytes,hypothesis,mythx_models,prompt_toolkit,psutil,py,pygments,pytest,pythx,requests,semantic_version,setuptools,solcast,solcx,tqdm,vyper,web3,xdist,yaml
 line_length = 100


### PR DESCRIPTION
### What I did
Fix an issue when making a call to a contract with no owner while evaluating coverage. Again.