### PR TITLE
Add interactive mode for unit testing

### DIFF
--- a/brownie/_cli/console.py
+++ b/brownie/_cli/console.py
@@ -71,7 +71,13 @@ class _Quitter:
 
 
 class Console(code.InteractiveConsole):
-    def __init__(self, project=None, inp=None):
+
+    # This value is used as the `input` arg when initializing `prompt_toolkit.PromptSession`.
+    # During testing there is a conflict with how pytest supresses stdin/out, so stdin is
+    # replaced with `prompt_toolkit.input.defaults.create_pipe_input`
+    prompt_input = None
+
+    def __init__(self, project=None):
         """
         Launch the Brownie console.
 
@@ -79,9 +85,6 @@ class Console(code.InteractiveConsole):
         ---------
         project : `Project`, optional
             Active Brownie project to include in the console's local namespace.
-        inp : Input, optional
-            Input object to be passed to the prompt_toolkit `PromptSession`.
-            Required for unit testing to avoid conflicts with Pytest.
         """
         console_settings = CONFIG.settings["console"]
 
@@ -126,7 +129,9 @@ class Console(code.InteractiveConsole):
         if console_settings["completions"]:
             kwargs["completer"] = ConsoleCompleter(locals_dict)
         self.prompt_session = PromptSession(
-            history=SanitizedFileHistory(history_file, locals_dict), input=inp, **kwargs
+            history=SanitizedFileHistory(history_file, locals_dict),
+            input=self.prompt_input,
+            **kwargs,
         )
 
         if console_settings["auto_suggest"]:

--- a/brownie/_cli/test.py
+++ b/brownie/_cli/test.py
@@ -15,6 +15,7 @@ Arguments:
 Brownie Options:
   --update -U              Only run tests where changes have occurred
   --coverage -C            Evaluate contract test coverage
+  --interactive -I         Open an interactive console each time a test fails
   --stateful [true,false]  Only run stateful tests, or skip them
   --revert-tb -R           Show detailed traceback on unhandled transaction reverts
   --gas -G                 Display gas profile for function calls

--- a/brownie/test/plugin.py
+++ b/brownie/test/plugin.py
@@ -22,6 +22,12 @@ def pytest_addoption(parser):
             "--revert-tb", "-R", action="store_true", help="Show detailed traceback on tx reverts"
         )
         parser.addoption(
+            "--interactive",
+            "-I",
+            action="store_true",
+            help="Open an interactive console each time a test fails",
+        )
+        parser.addoption(
             "--stateful",
             choices=["true", "false"],
             default=None,
@@ -48,6 +54,8 @@ def pytest_configure(config):
             config.option.verbose = True
 
         if config.getoption("numprocesses"):
+            if config.getoption("interactive"):
+                raise ValueError("Cannot use --interactive mode with xdist")
             Plugin = PytestBrownieMaster
         elif hasattr(config, "workerinput"):
             Plugin = PytestBrownieXdistRunner

--- a/docs/core-transactions.rst
+++ b/docs/core-transactions.rst
@@ -4,7 +4,7 @@
 Inspecting and Debugging Transactions
 =====================================
 
-Each time your perform a transaction you are returned a :func:`TransactionReceipt <brownie.network.transaction.TransactionReceipt>`. This object contains all relevant information about the transaction, as well as various methods to aid in debugging.
+Each time you perform a transaction you are returned a :func:`TransactionReceipt <brownie.network.transaction.TransactionReceipt>`. This object contains all relevant information about the transaction, as well as various methods to aid in debugging.
 
 .. code-block:: python
 

--- a/docs/tests-pytest-intro.rst
+++ b/docs/tests-pytest-intro.rst
@@ -358,6 +358,24 @@ Brownie compares hashes of the following items to check if a test should be re-r
 * The AST of the test module
 * The AST of all ``conftest.py`` modules that are accessible to the test module
 
+Interactive Debugging
+---------------------
+
+The ``--interactive`` flag allows you to debug your project while running your tests:
+
+::
+
+    $ brownie test --interactive
+
+When using interactive mode, Brownie immediately prints the traceback for each failed test and then opens a console. You can interact with the deployed contracts and examine the transaction history to help determine what went wrong.
+
+* Deployed :func:`ProjectContract <brownie.network.contract.ProjectContract>` objects are available within their associated :func:`ContractContainer <brownie.network.contract.ContractContainer>`
+* :func:`TransactionReceipt <brownie.network.transaction.TransactionReceipt>` objects are in the :func:`TxHistory <brownie.network.state.TxHistory>` container, available as ``history``
+
+Once you are finished, type ``quit()`` to continue with the next test.
+
+See :ref:`Inspecting and Debugging Transactions <core-transactions>` for more information on Brownie's debugging functionality.
+
 Evaluating Coverage
 -------------------
 

--- a/tests/test/plugin/test_interactive_console.py
+++ b/tests/test/plugin/test_interactive_console.py
@@ -1,0 +1,22 @@
+#!/usr/bin/python3
+
+test_source = """
+def test_that_fails():
+    assert False
+
+def test_that_also_fails():
+    assert False
+    """
+
+
+def test_interact(plugintester, mocker, monkeypatch, console):
+
+    monkeypatch.setattr("brownie._cli.console.Console.__init__", lambda *args, **kwargs: None)
+    monkeypatch.setattr("brownie._cli.console.Console.interact", lambda *args, **kwargs: None)
+    mocker.spy(console, "interact")
+
+    plugintester.runpytest()
+    assert not console.interact.call_count
+
+    plugintester.runpytest("--interactive")
+    assert console.interact.call_count == 2


### PR DESCRIPTION
### What I did
Add the `--interactive` flag to open a console during testing.  Closes #443.

### How I did it
* Use the `pytest_exception_interact` plugin hook to enter a brownie `Console` on a failed test, if the `--interactive` flag is active.
* Add a variant of `_sitebuiltins.Quitter` to handle `quit` and `exit` commands without closing `stdin`.
* Tests and docs

### How to verify it
Run tests.
