### PR TITLE
Rpc.undo and Rpc.redo

### DIFF
--- a/brownie/network/account.py
+++ b/brownie/network/account.py
@@ -274,6 +274,12 @@ class _PrivateKeyAccount(PublicKeyAccount):
         )
         add_thread = threading.Thread(target=contract._add_from_tx, args=(tx,), daemon=True)
         add_thread.start()
+        if rpc.is_active():
+            rpc._add_to_undo_buffer(
+                self.deploy,
+                (contract, *args),
+                {"amount": amount, "gas_limit": gas_limit, "gas_price": gas_price},
+            )
         if tx.status != 1:
             return tx
         add_thread.join()
@@ -338,6 +344,10 @@ class _PrivateKeyAccount(PublicKeyAccount):
             revert_data = None
         except ValueError as e:
             txid, revert_data = _raise_or_return_tx(e)
+
+        if rpc.is_active():
+            rpc._add_to_undo_buffer(self.transfer, (to, amount, gas_limit, gas_price, data), {})
+
         return TransactionReceipt(txid, self, revert_data=revert_data)
 
 

--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -842,14 +842,13 @@ class ContractCall(_ContractMethod):
 
         if not CONFIG.argv["always_transact"]:
             return self.call(*args)
-        rpc._internal_snap()
         args, tx = _get_tx(self._owner, args)
         tx.update({"gas_price": 0, "from": self._owner or accounts[0]})
         try:
             tx = self.transact(*args, tx)
             return tx.return_value
         finally:
-            rpc._internal_revert()
+            rpc.undo()
 
 
 def _get_tx(owner: Optional[AccountsType], args: Tuple) -> Tuple:

--- a/docs/api-network.rst
+++ b/docs/api-network.rst
@@ -1616,20 +1616,39 @@ Rpc Methods
         >>> accounts[0].balance()
         100000000000000000000
 
-Rpc Internal Methods
-********************
+.. py:classmethod:: Rpc.undo(num=1)
 
-.. py:classmethod:: Rpc._internal_snap()
+    Undo one or more recent transactions.
 
-    Takes an internal snapshot at the current block height.
+    * ``num``: Number of transactions to undo
 
-.. py:classmethod:: Rpc._internal_revert()
+    Once undone, a transaction can be repeated using :func:`Rpc.redo <Rpc.redo>`. Calling :func:`Rpc.snapshot <Rpc.snapshot>` or :func:`Rpc.revert <Rpc.revert>` clears the undo buffer.
 
-    Reverts to the most recently taken internal snapshot.
+    .. code-block:: python
 
-    .. note::
+        >>> web3.eth.blockNumber
+        3
+        >>> rpc.undo()
+        'Block height at 2'
 
-        When calling this method, you must ensure that the user has not had a chance to take their own snapshot since :func:`_internal_snap <Rpc._internal_snap>` was called.
+
+.. py:classmethod:: Rpc.redo(num=1)
+
+    Redo one or more recently undone transactions.
+
+    * ``num``: Number of transactions to redo
+
+    .. code-block:: python
+
+        >>> web3.eth.blockNumber
+        2
+        >>> rpc.redo()
+        Transaction sent: 0x8c166b66b356ad7f5c58337973b89950f03105cdae896ac66f16cdd4fc395d05
+          Gas price: 0.0 gwei   Gas limit: 6721975
+          Transaction confirmed - Block: 3   Gas used: 21000 (0.31%)
+
+        'Block height at 3'
+
 
 Internal Methods
 ----------------

--- a/docs/core-rpc.rst
+++ b/docs/core-rpc.rst
@@ -77,3 +77,29 @@ To return to the genesis state, use :func:`rpc.reset <Rpc.reset>`.
     >>> rpc.reset()
     >>> web3.eth.blockNumber
     0
+
+Undo / Redo
+-----------
+
+Along with snapshotting, you can use :func:`rpc.undo <Rpc.undo>` and :func:`rpc.redo <Rpc.redo>` to move backward and forward through recent transactions. This is especially useful during :ref:`interactive test debugging <pytest-interactive>`.
+
+.. code-block:: python
+
+    >>> accounts[0].transfer(accounts[1], "1 ether")
+    Transaction sent: 0x8c166b66b356ad7f5c58337973b89950f03105cdae896ac66f16cdd4fc395d05
+      Gas price: 0.0 gwei   Gas limit: 6721975
+      Transaction confirmed - Block: 1   Gas used: 21000 (0.31%)
+
+    <Transaction '0x8c166b66b356ad7f5c58337973b89950f03105cdae896ac66f16cdd4fc395d05'>
+
+    >>> rpc.undo()
+    'Block height at 0'
+
+    >>> rpc.redo()
+    Transaction sent: 0x8c166b66b356ad7f5c58337973b89950f03105cdae896ac66f16cdd4fc395d05
+      Gas price: 0.0 gwei   Gas limit: 6721975
+      Transaction confirmed - Block: 1   Gas used: 21000 (0.31%)
+
+    'Block height at 1'
+
+Note that :func:`rpc.snapshot <Rpc.snapshot>` and :func:`rpc.revert <Rpc.revert>` clear the undo buffer.

--- a/docs/tests-pytest-intro.rst
+++ b/docs/tests-pytest-intro.rst
@@ -358,6 +358,8 @@ Brownie compares hashes of the following items to check if a test should be re-r
 * The AST of the test module
 * The AST of all ``conftest.py`` modules that are accessible to the test module
 
+.. _pytest-interactive:
+
 Interactive Debugging
 ---------------------
 
@@ -371,6 +373,7 @@ When using interactive mode, Brownie immediately prints the traceback for each f
 
 * Deployed :func:`ProjectContract <brownie.network.contract.ProjectContract>` objects are available within their associated :func:`ContractContainer <brownie.network.contract.ContractContainer>`
 * :func:`TransactionReceipt <brownie.network.transaction.TransactionReceipt>` objects are in the :func:`TxHistory <brownie.network.state.TxHistory>` container, available as ``history``
+* Use :func:`rpc.undo <Rpc.undo>` and :func:`rpc.redo <Rpc.redo>` to move backward and forward through recent transactions
 
 Once you are finished, type ``quit()`` to continue with the next test.
 

--- a/tests/network/contract/test_contractcall.py
+++ b/tests/network/contract/test_contractcall.py
@@ -28,7 +28,7 @@ def test_always_transact(accounts, tester, argv, web3, monkeypatch, history):
     result = tester.owner()
     assert owner == result
     assert web3.eth.blockNumber == height == len(history)
-    monkeypatch.setattr("brownie.network.rpc._internal_revert", lambda: None)
+    monkeypatch.setattr("brownie.network.rpc.undo", lambda: None)
     result = tester.owner()
     tx = history[-1]
     assert owner == result

--- a/tests/network/rpc/conftest.py
+++ b/tests/network/rpc/conftest.py
@@ -35,6 +35,7 @@ def _no_rpc_setup(rpc, web3, temp_port, original_port):
     _notify_registry(0)
     rpc._rpc = proc
     rpc._reset_id = reset_id
+    rpc._current_id = reset_id
 
 
 @pytest.fixture

--- a/tests/network/rpc/test_redo.py
+++ b/tests/network/rpc/test_redo.py
@@ -1,0 +1,73 @@
+#!/usr/bin/python3
+
+
+import pytest
+
+
+def test_redo(accounts, rpc, web3):
+    accounts[0].transfer(accounts[1], "1 ether")
+    result = accounts[0].balance()
+    rpc.undo()
+    rpc.redo()
+    assert web3.eth.blockNumber == 1
+    assert accounts[0].balance() == result
+
+
+def test_redo_multiple(accounts, rpc, web3):
+    for i in range(1, 6):
+        accounts[0].transfer(accounts[i], "1 ether")
+    result = accounts[0].balance()
+    rpc.undo(5)
+    rpc.redo(5)
+    assert accounts[0].balance() == result
+
+
+def test_redo_contract_tx(tester, accounts, rpc, history):
+    tester.receiveEth({"from": accounts[0], "amount": "1 ether"})
+    rpc.undo()
+    rpc.redo()
+    assert history[-1].fn_name == "receiveEth"
+
+
+def test_redo_deploy(BrownieTester, accounts, rpc):
+    BrownieTester.deploy(True, {"from": accounts[0]})
+    rpc.undo()
+    rpc.redo()
+    assert len(BrownieTester) == 1
+
+
+def test_redo_empty_buffer(accounts, rpc):
+    with pytest.raises(ValueError):
+        rpc.redo()
+
+
+def test_redo_zero(accounts, rpc):
+    with pytest.raises(ValueError):
+        rpc.redo(0)
+
+
+def test_redo_too_many(accounts, rpc):
+    accounts[0].transfer(accounts[1], 100)
+    accounts[0].transfer(accounts[1], 100)
+    rpc.undo()
+    with pytest.raises(ValueError):
+        rpc.redo(2)
+
+
+def test_snapshot_clears_redo_buffer(accounts, rpc):
+    accounts[0].transfer(accounts[1], 100)
+    accounts[0].transfer(accounts[1], 100)
+    rpc.undo()
+    rpc.snapshot()
+    with pytest.raises(ValueError):
+        rpc.redo()
+
+
+def test_revert_clears_undo_buffer(accounts, rpc):
+    rpc.snapshot()
+    accounts[0].transfer(accounts[1], 100)
+    accounts[0].transfer(accounts[1], 100)
+    rpc.undo()
+    rpc.revert()
+    with pytest.raises(ValueError):
+        rpc.redo()

--- a/tests/network/rpc/test_undo.py
+++ b/tests/network/rpc/test_undo.py
@@ -1,0 +1,52 @@
+#!/usr/bin/python3
+
+import pytest
+
+
+def test_undo(accounts, rpc, web3):
+    initial = accounts[0].balance()
+    accounts[0].transfer(accounts[1], "1 ether")
+    rpc.undo()
+    assert web3.eth.blockNumber == 0
+    assert accounts[0].balance() == initial
+
+
+def test_undo_multiple(accounts, rpc, web3):
+    initial = accounts[0].balance()
+    for i in range(1, 6):
+        accounts[0].transfer(accounts[i], "1 ether")
+    rpc.undo(5)
+    assert accounts[0].balance() == initial
+
+
+def test_undo_empty_buffer(accounts, rpc):
+    with pytest.raises(ValueError):
+        rpc.undo()
+
+
+def test_undo_zero(accounts, rpc):
+    accounts[0].transfer(accounts[1], 100)
+    with pytest.raises(ValueError):
+        rpc.undo(0)
+
+
+def test_undo_too_many(accounts, rpc):
+    accounts[0].transfer(accounts[1], 100)
+    with pytest.raises(ValueError):
+        rpc.undo(2)
+
+
+def test_snapshot_clears_undo_buffer(accounts, rpc):
+    accounts[0].transfer(accounts[1], 100)
+    rpc.snapshot()
+    with pytest.raises(ValueError):
+        rpc.undo()
+
+
+def test_revert_clears_undo_buffer(accounts, rpc):
+    accounts[0].transfer(accounts[1], 100)
+    rpc.snapshot()
+    accounts[0].transfer(accounts[1], 100)
+    rpc.revert()
+    with pytest.raises(ValueError):
+        rpc.undo()

--- a/tests/test/plugin/test_coverage.py
+++ b/tests/test/plugin/test_coverage.py
@@ -19,26 +19,22 @@ def setup(no_call_coverage):
 
 
 def test_always_transact(plugintester, mocker, rpc):
-    mocker.spy(rpc, "_internal_snap")
-    mocker.spy(rpc, "_internal_revert")
+    mocker.spy(rpc, "undo")
 
     result = plugintester.runpytest()
     result.assert_outcomes(passed=1)
-    assert rpc._internal_snap.call_count == 0
-    assert rpc._internal_revert.call_count == 0
+    assert rpc.undo.call_count == 0
 
     # with coverage eval
     result = plugintester.runpytest("--coverage")
     result.assert_outcomes(passed=1)
-    assert rpc._internal_snap.call_count == 1
-    assert rpc._internal_revert.call_count == 1
+    assert rpc.undo.call_count == 1
 
     # with coverage and no_call_coverage fixture
     plugintester.makeconftest(conf_source)
     result = plugintester.runpytest("--coverage")
     result.assert_outcomes(passed=1)
-    assert rpc._internal_snap.call_count == 1
-    assert rpc._internal_revert.call_count == 1
+    assert rpc.undo.call_count == 1
 
 
 def test_coverage_tx(json_path, plugintester):


### PR DESCRIPTION
### What I did
Add `rpc.undo` and `rpc.redo` methods. Closes #454 

### How I did it
* `Rpc._add_to_undo_buffer` keeps a record of each transaction, and takes a new snapshot each time a transaction is performed.
* `Rpc.undo` and `Rpc.redo` move through the undo buffer.

### How to verify it
Run tests.
