### PR TITLE
fix: add missing API params for pytest print function

### DIFF
--- a/brownie/test/managers/runner.py
+++ b/brownie/test/managers/runner.py
@@ -74,12 +74,18 @@ class PytestPrinter:
         self.first_line = True
         builtins.print = self
 
-    def __call__(self, text):
+    def __call__(self, *values, sep=" ", end="\n", file=sys.stdout, flush=False):
+        if file != sys.stdout:
+            self._builtins_print(*values, sep=sep, end=end, file=file, flush=flush)
+            return
+
         if self.first_line:
             self.first_line = False
             sys.stdout.write(f"{color('yellow')}RUNNING{color}\n")
-        sys.stdout.write(f"{text}\n")
-        sys.stdout.flush()
+        text = f"{sep.join(values)}{end}"
+        sys.stdout.write(text)
+        if flush:
+            sys.stdout.flush()
 
     def finish(self, nodeid):
         if not self.first_line:

--- a/tests/test/plugin/test_output.py
+++ b/tests/test/plugin/test_output.py
@@ -7,7 +7,7 @@ from brownie.test import output
 test_source = """
 def test_stuff(BrownieTester, accounts):
     c = accounts[0].deploy(BrownieTester, True)
-    print('oh hai mark')
+    print('oh hai', 'mark')
     c.doNothing({'from': accounts[0]})"""
 
 


### PR DESCRIPTION
### What I did
Add missing args/kwargs to the pytest `print` replacement. FIxes an issue reported by @skyge on [Gitter](https://gitter.im/eth-brownie/community?at=5ea92a0331a6d25d7c991f7b).

### How I did it
Adjustments to the `PytestPrinter` class in `brownie/test/managers/runner.py`