### PR TITLE
Do not raise on non-zero block height

### DIFF
--- a/brownie/exceptions.py
+++ b/brownie/exceptions.py
@@ -123,3 +123,11 @@ class UnsupportedLanguage(Exception):
 
 class InvalidPackage(Exception):
     pass
+
+
+class BrownieCompilerWarning(Warning):
+    pass
+
+
+class BrownieEnvironmentWarning(Warning):
+    pass

--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -24,6 +24,8 @@ from brownie.convert.utils import (
     get_type_strings,
 )
 from brownie.exceptions import (
+    BrownieCompilerWarning,
+    BrownieEnvironmentWarning,
     ContractExists,
     ContractNotFound,
     UndeployedLibrary,
@@ -564,7 +566,8 @@ class Contract(_DeployedContractBase):
                 warnings.warn(
                     "No Etherscan API token set. You may experience issues with rate limiting. "
                     "Visit https://etherscan.io/register to obtain a token, and then store it "
-                    "as the environment variable $ETHERSCAN_TOKEN"
+                    "as the environment variable $ETHERSCAN_TOKEN",
+                    BrownieEnvironmentWarning,
                 )
 
         if not silent:
@@ -600,7 +603,8 @@ class Contract(_DeployedContractBase):
             if not silent:
                 warnings.warn(
                     f"{address}: target compiler '{data['result'][0]['CompilerVersion']}' is "
-                    "unsupported by Brownie. Some functionality will not be available."
+                    "unsupported by Brownie. Some functionality will not be available.",
+                    BrownieCompilerWarning,
                 )
             return cls.from_abi(name, address, abi)
 
@@ -615,7 +619,10 @@ class Contract(_DeployedContractBase):
             build.update(abi=abi, natspec=implementation_contract._build["natspec"])
 
         if not _verify_deployed_code(address, build["deployedBytecode"], build["language"]):
-            warnings.warn(f"{address}: Locally compiled and on-chain bytecode do not match!")
+            warnings.warn(
+                f"{address}: Locally compiled and on-chain bytecode do not match!",
+                BrownieCompilerWarning,
+            )
             del build["pcMap"]
 
         self = cls.__new__(cls)

--- a/docs/api-brownie.rst
+++ b/docs/api-brownie.rst
@@ -18,7 +18,10 @@ The ``brownie`` package is the main package containing all of Brownie's function
 ``brownie.exceptions``
 ======================
 
-The ``exceptions`` module contains all Brownie ``Exception`` classes.
+The ``exceptions`` module contains all Brownie :class:`Exception` and :class:`Warning` classes.
+
+Exceptions
+----------
 
 .. py:exception:: brownie.exceptions.CompilerError
 
@@ -74,7 +77,7 @@ The ``exceptions`` module contains all Brownie ``Exception`` classes.
 
 .. py:exception:: brownie.exceptions.UnknownAccount
 
-    Raised when the :func:`Accounts <brownie.network.account.Accounts>` container cannot locate a specified `Account <brownie.network.account.Account>` object.
+    Raised when the :func:`Accounts <brownie.network.account.Accounts>` container cannot locate a specified :func:`Account <brownie.network.account.Account>` object.
 
 .. py:exception:: brownie.exceptions.UnsetENSName
 
@@ -86,7 +89,7 @@ The ``exceptions`` module contains all Brownie ``Exception`` classes.
 
 .. py:exception:: brownie.exceptions.RPCConnectionError
 
-    Raised when the RPC process is active and `web3 <brownie.network.web3.Web3>` is connected, but Brownie is unable to communicate with it.
+    Raised when the RPC process is active and :func:`web3 <brownie.network.web3.Web3>` is connected, but Brownie is unable to communicate with it.
 
 .. py:exception:: brownie.exceptions.RPCProcessError
 
@@ -99,6 +102,17 @@ The ``exceptions`` module contains all Brownie ``Exception`` classes.
 .. py:exception:: brownie.exceptions.VirtualMachineError
 
     Raised when a contract call causes the EVM to revert.
+
+Warnings
+--------
+
+.. py:exception:: brownie.exceptions.BrownieCompilerWarning
+
+    Raised by :func:`Contract.from_explorer <Contract.from_explorer>` when a contract cannot be compiled, or compiles successfully but produces unexpected bytecode.
+
+.. py:exception:: brownie.exceptions.BrownieEnvironmentWarning
+
+    Raised on unexpected environment conditions.
 
 ``brownie._config``
 ===================
@@ -118,7 +132,7 @@ ConfigDict
 
 .. py:class:: brownie._config.ConfigDict
 
-    Subclass of `dict <https://docs.python.org/3/library/stdtypes.html#mapping-types-dict>`_ that prevents adding new keys when locked. Used to hold config file settings.
+    Subclass of :class:`dict` that prevents adding new keys when locked. Used to hold config file settings.
 
     .. code-block:: python
 
@@ -132,7 +146,7 @@ ConfigDict Internal Methods
 
 .. py:classmethod:: ConfigDict._lock
 
-    Locks the :func:`ConfigDict <brownie._config.ConfigDict>`. When locked, attempts to add a new key will raise a ``KeyError``.
+    Locks the :func:`ConfigDict <brownie._config.ConfigDict>`. When locked, attempts to add a new key will raise a :class:`KeyError`.
 
     .. code-block:: python
 
@@ -155,7 +169,7 @@ ConfigDict Internal Methods
 
 .. py:classmethod:: ConfigDict._copy
 
-    Returns a copy of the object as a ``dict``.
+    Returns a copy of the object as a :class:`dict`.
 
 ``brownie._singleton``
 ======================

--- a/docs/api-network.rst
+++ b/docs/api-network.rst
@@ -62,7 +62,7 @@ The ``main`` module contains methods for conncting to or disconnecting from the 
 
     * If no argument is given, the current default is displayed.
     * If an integer value is given, this will be the default gas limit.
-    * If set to ``auto``, the gas limit is determined automatically via ``web3.eth.estimateGas``.
+    * If set to ``auto``, the gas limit is determined automatically via :meth:`web3.eth.estimateGas <web3.eth.Eth.estimateGas>`.
 
     Returns ``False`` if the gas limit is set automatically, or an ``int`` if it is set to a fixed value.
 
@@ -81,7 +81,7 @@ The ``main`` module contains methods for conncting to or disconnecting from the 
     Gets and optionally sets the default gas price.
 
     * If an integer value is given, this will be the default gas price.
-    * If set to ``auto``, the gas price is determined automatically via ``web3.eth.getPrice``.
+    * If set to ``auto``, the gas price is determined automatically via :attr:`web3.eth.gasPrice <web3.eth.Eth.gasPrice>`.
 
     Returns ``False`` if the gas price is set automatically, or an ``int`` if it is set to a fixed value.
 
@@ -204,7 +204,7 @@ Account
 
 .. py:class:: brownie.network.account.Account
 
-    An ethereum address that you control the private key for, and so can send transactions from. Generated automatically from ``web3.eth.accounts`` and stored in the :func:`Accounts <brownie.network.account.Accounts>` container.
+    An ethereum address that you control the private key for, and so can send transactions from. Generated automatically from :attr:`web3.eth.accounts <web3.eth.Eth.accounts>` and stored in the :func:`Accounts <brownie.network.account.Accounts>` container.
 
     .. code-block:: python
 
@@ -318,7 +318,7 @@ LocalAccount
 
 .. py:class:: brownie.network.account.LocalAccount
 
-    Functionally identical to :func:`Account <brownie.network.account.Account>`. The only difference is that a ``LocalAccount`` is one where the private key was directly inputted, and so is not found in ``web3.eth.accounts``.
+    Functionally identical to :func:`Account <brownie.network.account.Account>`. The only difference is that a ``LocalAccount`` is one where the private key was directly inputted, and so is not found in :attr:`web3.eth.accounts <web3.eth.Eth.accounts>`.
 
     .. note:: Resetting the RPC client will delete all ``LocalAccount`` objects from the :func:`Account <brownie.network.account.Accounts>` container.
 
@@ -2122,16 +2122,16 @@ TransactionReceipt Methods
 ``brownie.network.web3``
 ========================
 
-The ``web3`` module contains a slightly modified version of the web3.py ``Web3`` class that is used throughout various Brownie modules for RPC communication.
+The ``web3`` module contains a slightly modified version of the web3.py :class:`Web3 <web3.Web3>` class that is used throughout various Brownie modules for RPC communication.
 
 Web3
 ----
 
-See the `Web3 API documentation <https://web3py.readthedocs.io/en/stable/web3.main.html#web3.Web3>`_ for detailed information on all the methods and attributes available here. This document only outlines methods that differ from the normal ``Web3`` public interface.
+See the `Web3 API documentation <https://web3py.readthedocs.io/en/stable/web3.main.html#web3.Web3>`_ for detailed information on all the methods and attributes available here. This document only outlines methods that differ from the normal :class:`Web3 <web3.Web3>` public interface.
 
 .. py:class:: brownie.network.web3.Web3
 
-    Brownie subclass of ``Web3``. An instance is created at ``brownie.network.web3.web`` and available for import from the main package.
+    Brownie subclass of :class:`Web3 <web3.Web3>`. An instance is created at ``brownie.network.web3.web`` and available for import from the main package.
 
     .. code-block:: python
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -196,4 +196,5 @@ intersphinx_mapping = {
     "hypothesis": ("https://hypothesis.readthedocs.io/en/latest", None),
     "pytest": ("https://docs.pytest.org/en/latest/", None),
     "python": ("https://docs.python.org/3.8/", None),
+    "web3py": ("https://web3py.readthedocs.io/en/stable/", None),
 }

--- a/docs/core-contracts.rst
+++ b/docs/core-contracts.rst
@@ -140,15 +140,15 @@ Transaction Parameters
 When executing a transaction to a contract, you can optionally include a :py:class:`dict <dict>` of transaction parameters as the final input. It may contain the following values:
 
     * ``from``: the :func:`Account <brownie.network.account.Account>` that the transaction it sent from. If not given, the transaction is sent from the account that deployed the contract.
-    * ``gas_limit``: The amount of gas provided for transaction execution, in wei. If not given, the gas limit is determined using ``web3.eth.estimateGas``.
-    * ``gas_price``: The gas price for the transaction, in wei. If not given, the gas price is set according to ``web3.eth.getPrice``.
+    * ``gas_limit``: The amount of gas provided for transaction execution, in wei. If not given, the gas limit is determined using :meth:`web3.eth.estimateGas <web3.eth.Eth.estimateGas>`.
+    * ``gas_price``: The gas price for the transaction, in wei. If not given, the gas price is set according to :attr:`web3.eth.gasPrice <web3.eth.Eth.gasPrice>`.
     * ``amount``: The amount of Ether to include with the transaction, in wei.
 
 All integer values can also be given as strings that will be converted by :func:`Wei <brownie.convert.datatypes.Wei>`.
 
 .. note::
 
-    To maintain compatibility with ``web3.eth.sendTransaction``, you can use ``gas``, ``gasPrice`` and ``value`` as aliases for ``gas_limit``, ``gas_price``, and ``amount``.
+    To maintain compatibility with :meth:`web3.eth.sendTransaction <web3.eth.Eth.sendTransaction>`, you can use ``gas``, ``gasPrice`` and ``value`` as aliases for ``gas_limit``, ``gas_price``, and ``amount``.
 
 Calls
 -----

--- a/docs/core-types.rst
+++ b/docs/core-types.rst
@@ -57,7 +57,7 @@ The :func:`Fixed <brownie.convert.datatypes.Fixed>` class is used to handle Vype
     True
 
 
-Attempting to assign, compare or perform arithmetic against a float raises a ``TypeError``.
+Attempting to assign, compare or perform arithmetic against a float raises a :class:`TypeError`.
 
 .. code-block:: python
 


### PR DESCRIPTION
### What I did
Warn instead of raising an exception when block height is > 0 in development network - Closes #453 

I also got distracted and added some intersphinx docs references for `web3py`

### How I did it
* add brownie `Warning` classes, implement them in existing warnings
* warn instead of raising on block height > 0
* add documentation

### How to verify it
Run tests.