### PR TITLE
InterfaceContainer and InterfaceConstructor

### DIFF
--- a/brownie/_cli/compile.py
+++ b/brownie/_cli/compile.py
@@ -24,8 +24,10 @@ def main():
     project_path = project.check_for_project(".")
     if project_path is None:
         raise ProjectNotFound
-    build_path = project_path.joinpath("build/contracts")
+    contract_artifact_path = project_path.joinpath("build/contracts")
+    interface_artifact_path = project_path.joinpath("build/interfaces")
     if args["--all"]:
-        shutil.rmtree(build_path, ignore_errors=True)
+        shutil.rmtree(contract_artifact_path, ignore_errors=True)
+        shutil.rmtree(interface_artifact_path, ignore_errors=True)
     project.load(project_path)
-    print(f"Brownie project has been compiled at {build_path}")
+    print(f"Project has been compiled. Build artifacts saved at {contract_artifact_path}")

--- a/brownie/_cli/console.py
+++ b/brownie/_cli/console.py
@@ -292,6 +292,8 @@ class TestAutoSuggest(AutoSuggest):
                 fn = getattr(base, current)
             if isinstance(fn, type):
                 fn = fn.__init__
+            elif hasattr(fn, "__call__"):
+                fn = fn.__call__
 
             if hasattr(fn, "_autosuggest"):
                 inputs = fn._autosuggest()

--- a/brownie/_gui/root.py
+++ b/brownie/_gui/root.py
@@ -133,6 +133,8 @@ class ToolbarFrame(ttk.Frame):
         ToolTip(self.report, "Select a report to overlay onto the source code")
 
         # contract selection
-        self.combo = ContractSelect(self, [k for k, v in project._build.items() if v["bytecode"]])
+        self.combo = ContractSelect(
+            self, [k for k, v in project._build.items() if v.get("bytecode")]
+        )
         self.combo.grid(row=0, column=10, sticky="nsew")
         ToolTip(self.combo, "Select the contract source to view")

--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -630,7 +630,7 @@ class Contract(_DeployedContractBase):
         build = compile_and_format(sources, solc_version=str(version), optimizer=optimizer)
         build = build[name]
         if as_proxy_for is not None:
-            build.update(abi=abi, natspec=implementation_contract._build["natspec"])
+            build.update(abi=abi, natspec=implementation_contract._build.get("natspec"))
 
         if not _verify_deployed_code(address, build["deployedBytecode"], build["language"]):
             warnings.warn(

--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -248,6 +248,35 @@ class ContractConstructor:
         return bytecode + eth_abi.encode_abi(types_list, data).hex()
 
 
+class InterfaceContainer:
+    """
+    Container class that provides access to interfaces within a project.
+    """
+
+    def __init__(self, project: Any) -> None:
+        self._project = project
+
+    def _add(self, name: str, abi: List) -> None:
+        constructor = InterfaceConstructor(name, abi)
+        setattr(self, name, constructor)
+
+
+class InterfaceConstructor:
+    """
+    Constructor used to create Contract objects from a project interface.
+    """
+
+    def __init__(self, name: str, abi: List) -> None:
+        self._name = name
+        self.abi = abi
+
+    def __call__(self, address: str, owner: Optional[AccountsType] = None) -> "Contract":
+        return Contract.from_abi(self._name, address, self.abi, owner)
+
+    def __repr__(self) -> str:
+        return f"<{type(self).__name__} '{self._name}'>"
+
+
 class _DeployedContractBase(_ContractBase):
     """Methods for interacting with a deployed contract.
 
@@ -445,7 +474,7 @@ class Contract(_DeployedContractBase):
 
     @classmethod
     def from_abi(
-        cls, name: str, address: str, abi: Dict, owner: Optional[AccountsType] = None
+        cls, name: str, address: str, abi: List, owner: Optional[AccountsType] = None
     ) -> "Contract":
         """
         Create a new `Contract` object from an ABI.

--- a/brownie/project/main.py
+++ b/brownie/project/main.py
@@ -281,7 +281,12 @@ class Project(_ProjectBase):
             if path.suffix == ".json":
                 abi = json.loads(source)
             elif path.suffix == ".vy":
-                abi = compiler.vyper.get_abi(source, name)[name]
+                try:
+                    abi = compiler.vyper.get_abi(source, name)[name]
+                except Exception:
+                    # vyper interfaces do not convert to ABIs
+                    # https://github.com/vyperlang/vyper/issues/1944
+                    continue
             else:
                 abi = compiler.solidity.get_abi(source)[name]
             data = {"abi": abi, "contractName": name, "type": "interface", "sha1": new_hashes[name]}

--- a/brownie/test/fixtures.py
+++ b/brownie/test/fixtures.py
@@ -21,6 +21,7 @@ def _generate_fixture(container):
 class PytestBrownieFixtures:
     def __init__(self, config, project):
         self.config = config
+        self._interface = project.interface
         for container in project:
             setattr(self, container._name, _generate_fixture(container))
 
@@ -69,6 +70,10 @@ class PytestBrownieFixtures:
     def history(self):
         """Yields a TxHistory container for the active project, used to access transaction data."""
         yield brownie.history
+
+    @pytest.fixture(scope="session")
+    def interface(self):
+        yield self._interface
 
     @pytest.fixture(scope="session")
     def rpc(self):

--- a/brownie/test/managers/base.py
+++ b/brownie/test/managers/base.py
@@ -27,7 +27,7 @@ class PytestBrownieBase:
         self.isolated = {}
         self.skip = {}
         self.contracts = dict(
-            (k, v["bytecodeSha1"]) for k, v in project._build.items() if v["bytecode"]
+            (k, v["bytecodeSha1"]) for k, v in project._build.items() if v.get("bytecode")
         )
 
         glob = self.project_path.glob("tests/**/conftest.py")

--- a/docs/api-network.rst
+++ b/docs/api-network.rst
@@ -608,7 +608,7 @@ ContractContainer Attributes
 
 .. py:attribute:: ContractContainer.topics
 
-    A dictionary of bytes32 topics for each contract event.
+    A :py:class:`dict` of bytes32 topics for each contract event.
 
     .. code-block:: python
 
@@ -631,7 +631,7 @@ ContractContainer Methods
 
     * ``*args``: Contract constructor arguments.
 
-    You can optionally include a dictionary of :ref:`transaction parameters<transaction-parameters>` as the final argument. If you omit this or do not specify a ``'from'`` value, the transaction will be sent from the same address that deployed the contract.
+    You can optionally include a :py:class:`dict` of :ref:`transaction parameters<transaction-parameters>` as the final argument. If you omit this or do not specify a ``'from'`` value, the transaction will be sent from the same address that deployed the contract.
 
     If the contract requires a library, the most recently deployed one will be used. If the required library has not been deployed yet an `UndeployedLibrary <brownie.exceptions.UndeployedLibrary>` exception is raised.
 
@@ -779,7 +779,7 @@ New ``Contract`` objects are created with one of the following class methods.
     .. code-block:: python
 
         >>> from brownie import Contract
-        >>> Contract("Token", "0x79447c97b6543F6eFBC91613C655977806CB18b0", abi)
+        >>> Contract.from_abi("Token", "0x79447c97b6543F6eFBC91613C655977806CB18b0", abi)
         <Token Contract object '0x79447c97b6543F6eFBC91613C655977806CB18b0'>
 
 
@@ -971,7 +971,7 @@ ContractTx
 
     Inputs are formatted via methods in the :ref:`convert<api-convert>` module.
 
-    You can optionally include a dictionary of :ref:`transaction parameters<transaction-parameters>` as the final argument. If you omit this or do not specify a ``'from'`` value, the transaction will be sent from the same address that deployed the contract.
+    You can optionally include a :py:class:`dict` of :ref:`transaction parameters<transaction-parameters>` as the final argument. If you omit this or do not specify a ``'from'`` value, the transaction will be sent from the same address that deployed the contract.
 
     .. code-block:: python
 
@@ -1066,7 +1066,7 @@ OverloadedMethod
 
 .. py:class:: brownie.network.contract.OverloadedMethod(address, name, owner)
 
-    When a contract uses `overloaded function names <https://solidity.readthedocs.io/en/latest/contracts.html#function-overloading>`_, the :func:`ContractTx <brownie.network.contract.ContractTx>` or :func:`ContractCall <brownie.network.contract.ContractCall>` objects are stored inside a dict-like ``OverloadedMethod`` container.
+    When a contract uses `overloaded function names <https://solidity.readthedocs.io/en/latest/contracts.html#function-overloading>`_, the :func:`ContractTx <brownie.network.contract.ContractTx>` or :func:`ContractCall <brownie.network.contract.ContractCall>` objects are stored inside a :py:class:`dict`-like ``OverloadedMethod`` container.
 
     .. code-block:: python
 
@@ -1084,7 +1084,46 @@ OverloadedMethod
         >>> erc223.transfer['address', 'uint256', 'uint256']
         <ContractTx object 'transfer(address,uint256,uint256)'>
 
+InterfaceContainer
+------------------
 
+.. py:class:: brownie.network.contract.InterfaceContainer
+
+    Container class that provides access to interfaces within a project.
+
+    This object is created and populated with :func:`InterfaceConstructor <brownie.network.contract.InterfaceConstructor>` objects when a Brownie project is opened. It is available as ``interface`` within the console and as a pytest fixture.
+
+    .. code-block:: python
+
+        >>> interface
+        <brownie.network.contract.InterfaceContainer object at 0x7fa239bf0d30>
+
+InterfaceConstructor
+--------------------
+
+.. py:class:: brownie.network.contract.InterfaceConstructor(address, owner=None)
+
+    Constructor to create :func:`Contract <brownie.network.contract.Contract>` objects from a project interface.
+
+    * ``address_or_alias``: Address of the deployed contract.
+    * ``owner``: An optional :func:`Account <brownie.network.account.Account>` instance. If given, transactions to the contract are sent broadcasted from this account by default.
+
+    When a project is loaded, an ``InterfaceConstructor`` is generated from each interface file within the ``interfaces/`` folder of the project. These objects are stored as :func:`InterfaceContainer <brownie.network.contract.InterfaceContainer>` members.
+
+    .. code-block:: python
+
+        >>> interface.Dai
+        <InterfaceConstructor 'Dai'>
+
+        >>> interface.Dai("0x6B175474E89094C44Da98b954EedeAC495271d0F")
+        <Dai Contract object '0x6B175474E89094C44Da98b954EedeAC495271d0F'>
+
+InterfaceConstructor Attributes
+*******************************
+
+.. py:attribute:: InterfaceConstructor.abi
+
+    The interface ABI as a :py:class:`dict`.
 
 ``brownie.network.event``
 =========================
@@ -1098,7 +1137,7 @@ EventDict
 
 .. py:class:: brownie.network.event.EventDict
 
-    Hybrid container type that works as a `dict <https://docs.python.org/3/library/stdtypes.html#mapping-types-dict>`_ and a `list <https://docs.python.org/3/library/stdtypes.html#lists>`_. Base class, used to hold all events that are fired in a transaction.
+    Hybrid container type that works as a :py:class:`dict` and a :py:class:`list`. Base class, used to hold all events that are fired in a transaction.
 
     When accessing events inside the object:
 
@@ -1178,7 +1217,7 @@ _EventItem
 
 .. py:class:: brownie.network.event._EventItem
 
-    Hybrid container type that works as a `dict <https://docs.python.org/3/library/stdtypes.html#mapping-types-dict>`_ and a `list <https://docs.python.org/3/library/stdtypes.html#lists>`_. Represents one or more events with the same name that were fired in a transaction.
+    Hybrid container type that works as a :py:class:`dict` and a :py:class:`list`. Represents one or more events with the same name that were fired in a transaction.
 
     Instances of this class are created by :func:`EventDict <brownie.network.event.EventDict>`, it is not intended to be instantiated directly.
 
@@ -1338,7 +1377,7 @@ TxHistory Attributes
 
 .. py:attribute:: TxHistory.gas_profile
 
-    A dict that tracks gas cost statistics for contract function calls over time.
+    A :py:class:`dict` that tracks gas cost statistics for contract function calls over time.
 
     .. code-block:: python
 
@@ -1363,7 +1402,7 @@ TxHistory Methods
 
 .. py:classmethod:: TxHistory.copy
 
-    Returns a shallow copy of the object as a ``list``.
+    Returns a shallow copy of the object as a :py:class:`list`.
 
     .. code-block:: python
 

--- a/docs/build-folder.rst
+++ b/docs/build-folder.rst
@@ -38,6 +38,8 @@ Brownie generates compiler artifacts for each contract within a project, which a
         'type': "" // contract, library, interface
     }
 
+The ``build/interfaces`` folder contains compiler artifacts generated from project interfaces. These files use a similar structure, but only contain some of the fields listed above.
+
 .. note::
 
     The ``allSourcePaths`` field is used to map ``<SOURCE_ID>`` references to their actual paths.

--- a/docs/core-contracts.rst
+++ b/docs/core-contracts.rst
@@ -137,7 +137,7 @@ If you wish to call the contract method without a transaction, use the :func:`Co
 Transaction Parameters
 **********************
 
-When executing a transaction to a contract, you can optionally include a :py:class:`dict <dict>` of transaction parameters as the final input. It may contain the following values:
+When executing a transaction to a contract, you can optionally include a :py:class:`dict` of transaction parameters as the final input. It may contain the following values:
 
     * ``from``: the :func:`Account <brownie.network.account.Account>` that the transaction it sent from. If not given, the transaction is sent from the account that deployed the contract.
     * ``gas_limit``: The amount of gas provided for transaction execution, in wei. If not given, the gas limit is determined using :meth:`web3.eth.estimateGas <web3.eth.Eth.estimateGas>`.
@@ -179,19 +179,43 @@ Contracts Outside of your Project
 
 When working in a :ref:`live environment <network-management-live>` or :ref:`forked development network <network-management-fork>`, you can create :func:`Contract <brownie.network.contract.Contract>` objects to interact with already-deployed contracts.
 
-New :func:`Contract <brownie.network.contract.Contract>` objects are created using one of three :ref:`class methods <api-network-contract-classmethods>`. Options for creation include:
+:func:`Contract <brownie.network.contract.Contract>` objects may be created from interfaces within the ``interfaces/`` folder of your project, or by fetching information from a remote source such as a block explorer or ethPM registry.
 
-    * Fetching verified source code from a block explorer, such as `Etherscan <https://etherscan.io/>`_
-    * Providing an `ABI <https://solidity.readthedocs.io/en/latest/abi-spec.html#json>`_ and an address
-    * Fetching the information from an ethPM registry
+Using Local Interfaces
+----------------------
 
-For example, use :func:`Contract.from_explorer <Contract.from_explorer>` to create an object by querying Etherscan:
+The :func:`InterfaceContainer <brownie.network.contract.InterfaceContainer>` object (available as ``interface``) provides access to the interfaces within your project's ``interfaces/`` folder.
+
+For example, to create a :func:`Contract <brownie.network.contract.Contract>` object from an interface named ``Dai``:
+
+.. code-block:: python
+
+    >>> interface.Dai
+    <InterfaceConstructor 'Dai'>
+
+    >>> interface.Dai("0x6B175474E89094C44Da98b954EedeAC495271d0F")
+    <Dai Contract object '0x6B175474E89094C44Da98b954EedeAC495271d0F'>
+
+You can also use the :func:`Contract.from_abi <Contract.from_abi>` classmethod to instatiate from an ABI as a dictionary:
+
+.. code-block:: python
+
+    >>> Contract.from_abi("Token", "0x79447c97b6543F6eFBC91613C655977806CB18b0", abi)
+    <Token Contract object '0x79447c97b6543F6eFBC91613C655977806CB18b0'>
+
+Fetching from a Remote Source
+-----------------------------
+
+Contract objects may also be created by fetching data from a remote source. For example, use :func:`Contract.from_explorer <Contract.from_explorer>` to create an object by querying Etherscan:
 
 .. code-block:: python
 
     >>> Contract.from_explorer("0x6b175474e89094c44da98b954eedeac495271d0f")
     Fetching source of 0x6B175474E89094C44Da98b954EedeAC495271d0F from api.etherscan.io...
     <Dai Contract '0x6B175474E89094C44Da98b954EedeAC495271d0F'>
+
+Persisting Contracts between Sessions
+-------------------------------------
 
 The data used to create :func:`Contract <brownie.network.contract.Contract>` objects is stored in a local database and persists between sessions. After the initial creation via a :ref:`class method <api-network-contract-classmethods>`, you can recreate an object by initializing :func:`Contract <brownie.network.contract.Contract>` with an address:
 

--- a/docs/tests-pytest-fixtures.rst
+++ b/docs/tests-pytest-fixtures.rst
@@ -56,6 +56,17 @@ These fixtures provide quick access to Brownie objects that are frequently used 
             accounts[0].transfer(accounts[1], "10 ether")
             assert len(history) == 1
 
+.. py:attribute:: interface
+
+    Yields the :func:`InterfaceContainer <brownie.network.contract.InterfaceContainer>` object for the active project, which provides access to project interfaces.
+
+    .. code-block:: python
+        :linenos:
+
+        @pytest.fixture(scope="session")
+        def dai(interface):
+            yield interface.Dai("0x6B175474E89094C44Da98b954EedeAC495271d0F")
+
 .. py:attribute:: pm
 
     Callable fixture that provides access to :func:`Project <brownie.project.main.Project>` objects, used for testing against installed packages.

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,5 +25,11 @@ ignore_missing_imports = True
 follow_imports = silent
 
 [tool:pytest]
-addopts = -p no:pytest-brownie --cov=brownie/ --cov-report xml --ignore=tests/data/ -n auto
+addopts =
+    -p no:pytest-brownie
+    --cov brownie/
+    --cov-report term
+    --cov-report xml
+    --ignore tests/data/
+    -n auto
 

--- a/tests/network/contract/test_interface.py
+++ b/tests/network/contract/test_interface.py
@@ -1,0 +1,19 @@
+from brownie.network.contract import Contract, InterfaceConstructor, InterfaceContainer
+
+
+def test_interfacecontainer_add():
+    interface = InterfaceContainer(None)
+    interface._add("Test", [])
+
+    assert hasattr(interface, "Test")
+    assert isinstance(interface.Test, InterfaceConstructor)
+
+
+def test_interfaceconstructor_call(tester):
+    interface = InterfaceContainer(None)
+    interface._add("Test", [{"type": "foo"}])
+
+    contract = interface.Test(tester.address)
+
+    assert isinstance(contract, Contract)
+    assert contract.abi == [{"type": "foo"}]

--- a/tests/project/main/test_interfaces_solc.py
+++ b/tests/project/main/test_interfaces_solc.py
@@ -21,13 +21,13 @@ contract Bar is Foo {{
 """
 
 
-@pytest.mark.parametrize("contract_type", ("contract", "interface"))
-def test_in_contracts_folder(newproject, contract_type):
+def test_in_contracts_folder(newproject):
     with newproject._path.joinpath("contracts/Foo.sol").open("w") as fp:
-        fp.write(INTERFACE.format(contract_type))
+        fp.write(INTERFACE.format("interface"))
     newproject.load()
     assert newproject._path.joinpath("build/contracts/Foo.json").exists()
     assert not hasattr(newproject, "Foo")
+    assert hasattr(newproject.interface, "Foo")
 
 
 @pytest.mark.parametrize("contract_type", ("contract", "interface"))
@@ -37,6 +37,7 @@ def test_in_interfaces_folder(newproject, contract_type):
     newproject.load()
     assert not newproject._path.joinpath("build/contracts/Foo.json").exists()
     assert not hasattr(newproject, "Foo")
+    assert hasattr(newproject.interface, "Foo")
 
 
 @pytest.mark.parametrize("import_path", ("../", ""))

--- a/tests/project/main/test_interfaces_vyper.py
+++ b/tests/project/main/test_interfaces_vyper.py
@@ -38,6 +38,7 @@ def test_vy_interface(newproject):
     assert hasattr(newproject, "Foo")
     assert not newproject._path.joinpath("build/contracts/Bar.json").exists()
     assert not hasattr(newproject, "Bar")
+    assert not hasattr(newproject.interface, "Bar")
 
 
 def test_json_interface(newproject):
@@ -50,6 +51,7 @@ def test_json_interface(newproject):
     assert hasattr(newproject, "Foo")
     assert not newproject._path.joinpath("build/contracts/Bar.json").exists()
     assert not hasattr(newproject, "Bar")
+    assert hasattr(newproject.interface, "Bar")
 
 
 def test_incompatible_interface(newproject):

--- a/tests/test/plugin/test_session_fixtures.py
+++ b/tests/test/plugin/test_session_fixtures.py
@@ -12,6 +12,9 @@ def test_accounts(accounts, a):
 def test_history(history):
     assert history == brownie.history
 
+def test_interface(interface):
+    assert isinstance(interface, brownie.network.contract.InterfaceContainer)
+
 def test_rpc(rpc):
     assert rpc == brownie.rpc
 
@@ -37,9 +40,9 @@ def test_state_machine(state_machine):
 
 def test_fixtures(plugintester):
     result = plugintester.runpytest()
-    result.assert_outcomes(passed=6)
+    result.assert_outcomes(passed=7)
 
 
 def test_fixtures_xdist(isolatedtester):
     result = isolatedtester.runpytest("-n 2")
-    result.assert_outcomes(passed=6)
+    result.assert_outcomes(passed=7)


### PR DESCRIPTION
### What I did
Add `InterfaceContainer` and `InterfaceConstructor` objects.

Closes #436 

### How I did it
* All files within `interfaces/` are compiled and a stripped-down build artifact is stored at `build/interfaces/`
* These artifacts are used to create `InterfaceConstructor` objects, which act as a wrapper over `Contract.from_abi` to allow easy access to project interfaces.
* `InterfaceConstructor` objects are added as members of `InterfaceContainer` which is available as `interfaces` in the console and as a pytest fixture

### How to verify it
Run tests.
