### PR TITLE
Allow deployment via `account.transfer`

### DIFF
--- a/brownie/network/state.py
+++ b/brownie/network/state.py
@@ -97,6 +97,9 @@ class TxHistory(metaclass=_Singleton):
 
 
 def _find_contract(address: Any) -> Any:
+    if address is None:
+        return
+
     address = _resolve_address(address)
     if address in _contract_map:
         return _contract_map[address]

--- a/brownie/network/transaction.py
+++ b/brownie/network/transaction.py
@@ -316,9 +316,12 @@ class TransactionReceipt:
         self.block_number = receipt["blockNumber"]
         self.txindex = receipt["transactionIndex"]
         self.gas_used = receipt["gasUsed"]
-        self.contract_address = receipt["contractAddress"]
         self.logs = receipt["logs"]
         self.status = receipt["status"]
+
+        self.contract_address = receipt["contractAddress"]
+        if self.contract_address and not self.contract_name:
+            self.contract_name = "UnknownContract"
 
         base = (
             f"{self.nonce}{self.block_number}{self.sender}{self.receiver}"

--- a/docs/api-network.rst
+++ b/docs/api-network.rst
@@ -293,7 +293,7 @@ Account Methods
         >>> accounts[0].estimate_gas(accounts[1], "1 ether")
         21000
 
-.. py:classmethod:: Account.transfer(self, to, amount, gas_limit=None, gas_price=None, data="")
+.. py:classmethod:: Account.transfer(self, to=None, amount=0, gas_limit=None, gas_price=None, data=None)
 
     Broadcasts a transaction from this account.
 
@@ -312,6 +312,18 @@ Account Methods
         Transaction sent: 0x0173aa6938c3a5e50b6dc7b4d38e16dab40811ab4e00e55f3e0d8be8491c7852
         Transaction confirmed - block: 1   gas used: 21000 (100.00%)
         <Transaction object '0x0173aa6938c3a5e50b6dc7b4d38e16dab40811ab4e00e55f3e0d8be8491c7852'>
+
+    You can also deploy contracts by omitting the ``to`` field. Note that deploying with this method does not automatically create a :func:`Contract <brownie.network.contract.Contract>` object.
+
+    .. code-block:: python
+
+        >>> deployment_bytecode = "0x6103f056600035601c52740100..."
+        >>> accounts[0].transer(data=deployment_bytecode)
+        Transaction sent: 0x2b33315f7f9ec86d27112ea6dffb69b6eea1e582d4b6352245c0ac8e614fe06f
+          Gas price: 0.0 gwei   Gas limit: 6721975
+          Transaction confirmed - Block: 1   Gas used: 268460 (3.99%)
+          UnknownContract deployed at: 0x3194cBDC3dbcd3E11a07892e7bA5c3394048Cc87
+        <Transaction '0x2b33315f7f9ec86d27112ea6dffb69b6eea1e582d4b6352245c0ac8e614fe06f'>
 
 LocalAccount
 ------------

--- a/tests/network/account/test_account_transfer.py
+++ b/tests/network/account/test_account_transfer.py
@@ -172,3 +172,10 @@ def test_localaccount(accounts):
     local.transfer(accounts[1], "1 ether")
     assert accounts[1].balance() == "101 ether"
     assert local.nonce == 1
+
+
+def test_deploy_via_transfer(accounts, web3):
+    bytecode = "0x3660006000376110006000366000732157a7894439191e520825fe9399ab8655e0f7085af41558576110006000f3"  # NOQA: E501
+    tx = accounts[0].transfer(data=bytecode)
+    assert tx.contract_name == "UnknownContract"
+    assert web3.eth.getCode(tx.contract_address)


### PR DESCRIPTION
### What I did
Allow contract deployment via `Account.transfer`

### How I did it
* In `Account.transfer`, change `to` and `amount` inputs to optional kwargs.
* Fix bugs in `TransactionReceipt` when a transaction deploys a contract without the use of a `Contract` object.
* Add docs and tests

### How to verify it
Run the tests.
