### PR TITLE
Custom request timeout setting

### DIFF
--- a/brownie/_cli/networks.py
+++ b/brownie/_cli/networks.py
@@ -39,7 +39,7 @@ as well as possible data fields when declaring new networks."""
 
 DEV_REQUIRED = ("id", "host", "cmd", "cmd_settings")
 PROD_REQUIRED = ("id", "host", "chainid")
-OPTIONAL = ("name", "explorer")
+OPTIONAL = ("name", "explorer", "timeout")
 
 DEV_CMD_SETTINGS = (
     "port",

--- a/brownie/data/network-config.yaml
+++ b/brownie/data/network-config.yaml
@@ -54,6 +54,7 @@ development:
     id: mainnet-fork
     cmd: ganache-cli
     host: http://127.0.0.1
+    timeout: 120
     cmd_settings:
       port: 8545
       gas_limit: 10000000

--- a/brownie/network/main.py
+++ b/brownie/network/main.py
@@ -34,7 +34,7 @@ def connect(network: str = None, launch_rpc: bool = True) -> None:
             except KeyError:
                 pass
 
-        web3.connect(host)
+        web3.connect(host, active.get("timeout", 30))
         if CONFIG.network_type == "development" and launch_rpc and not rpc.is_active():
             if is_connected():
                 if web3.eth.blockNumber != 0:

--- a/brownie/network/web3.py
+++ b/brownie/network/web3.py
@@ -31,7 +31,7 @@ class Web3(_Web3):
         self._genesis_hash: Optional[str] = None
         self._chain_uri: Optional[str] = None
 
-    def connect(self, uri: str) -> None:
+    def connect(self, uri: str, timeout: int = 30) -> None:
         """Connects to a provider"""
         uri = _expand_environment_vars(uri)
         try:
@@ -43,7 +43,8 @@ class Web3(_Web3):
         if uri[:3] == "ws:":
             self.provider = WebsocketProvider(uri)
         elif uri[:4] == "http":
-            self.provider = HTTPProvider(uri, {"timeout": 30})
+
+            self.provider = HTTPProvider(uri, {"timeout": timeout})
         else:
             raise ValueError(
                 "Unknown URI - must be a path to an IPC socket, a websocket "

--- a/docs/api-network.rst
+++ b/docs/api-network.rst
@@ -2192,7 +2192,7 @@ See the `Web3 API documentation <https://web3py.readthedocs.io/en/stable/web3.ma
 Web3 Methods
 ************
 
-.. py:classmethod:: Web3.connect(uri)
+.. py:classmethod:: Web3.connect(uri, timeout=30)
 
     Connects to a `provider <https://web3py.readthedocs.io/en/stable/providers.html>`_. ``uri`` can be the path to a local IPC socket, a websocket address beginning in ``ws://`` or a URL.
 

--- a/docs/network-management.rst
+++ b/docs/network-management.rst
@@ -66,6 +66,7 @@ When declaring a new network, the following fields must always be included:
 The following fields are optional:
 
     * ``name`` A longer name to use for the network. If not given, ``id`` is used.
+    * ``timeout``: The number of seconds to wait for a response when making an RPC call. Defaults to 30.
 
 There are additional required and optional fields that are dependent on the type of network.
 


### PR DESCRIPTION
### What I did
Allow custom timeout value for networks.

### How I did it
* Add a `timeout` field for each network within `network-config.yaml` - if not present, the default value is 30 seconds
* Set the default timeout for `mainnet-fork` as 120 seconds.

### How to verify it
Run tests.
