### PR TITLE
expose silent parameter to transfer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This changelog format is based on [Keep a Changelog](https://keepachangelog.com/
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/iamdefinitelyahuman/brownie)
+### Changed
+- Exposed `silent` parameter to `Account.transfer()`  ([#472](https://github.com/iamdefinitelyahuman/brownie/pull/472))
 
 ## [1.8.0](https://github.com/iamdefinitelyahuman/brownie/tree/v1.8.0) - 2020-04-30
 ### Added

--- a/brownie/network/account.py
+++ b/brownie/network/account.py
@@ -317,6 +317,7 @@ class _PrivateKeyAccount(PublicKeyAccount):
         gas_limit: Optional[int] = None,
         gas_price: Optional[int] = None,
         data: str = None,
+        silent: bool = False,
     ) -> "TransactionReceipt":
         """
         Broadcast a transaction from this account.
@@ -327,6 +328,7 @@ class _PrivateKeyAccount(PublicKeyAccount):
             gas_limit: Gas limit of the transaction.
             gas_price: Gas price of the transaction.
             data: Hexstring of data to include in transaction.
+            silent: Toggles console verbosity.
 
         Returns:
             TransactionReceipt object
@@ -351,7 +353,7 @@ class _PrivateKeyAccount(PublicKeyAccount):
         if rpc.is_active():
             rpc._add_to_undo_buffer(self.transfer, (to, amount, gas_limit, gas_price, data), {})
 
-        return TransactionReceipt(txid, self, revert_data=revert_data)
+        return TransactionReceipt(txid, self, silent=silent, revert_data=revert_data)
 
 
 class Account(_PrivateKeyAccount):

--- a/docs/api-network.rst
+++ b/docs/api-network.rst
@@ -293,7 +293,7 @@ Account Methods
         >>> accounts[0].estimate_gas(accounts[1], "1 ether")
         21000
 
-.. py:classmethod:: Account.transfer(self, to=None, amount=0, gas_limit=None, gas_price=None, data=None)
+.. py:classmethod:: Account.transfer(self, to=None, amount=0, gas_limit=None, gas_price=None, data=None, silent=False)
 
     Broadcasts a transaction from this account.
 
@@ -302,6 +302,7 @@ Account Methods
     * ``gas_limit``: Gas limit for the transaction. The given value is converted to :func:`Wei <brownie.convert.datatypes.Wei>`. If none is given, the price is set using ``eth_estimateGas``.
     * ``gas_price``: Gas price for the transaction. The given value is converted to :func:`Wei <brownie.convert.datatypes.Wei>`. If none is given, the price is set using ``eth_gasPrice``.
     * ``data``: Transaction data hexstring.
+    * ``silent``: Toggles console verbosity. If ``True`` is given, suppresses all console output for this transaction.
 
     Returns a :func:`TransactionReceipt <brownie.network.transaction.TransactionReceipt>` instance.
 

--- a/tests/network/transaction/test_attributes.py
+++ b/tests/network/transaction/test_attributes.py
@@ -40,6 +40,13 @@ def test_contract_address(accounts, tester):
     assert tester.tx.receiver is None
 
 
+@pytest.mark.parametrize("silent", [False, True])
+def test_silent_mode(accounts, tester, console_mode, capsys, silent):
+    accounts[0].transfer(accounts[1], "1 ether", silent=silent)
+    captured = capsys.readouterr()
+    assert (captured.out == "") == silent
+
+
 def test_input(accounts, tester):
     data = tester.revertStrings.encode_input(5)
     tx = accounts[0].transfer(tester.address, 0, data=data)


### PR DESCRIPTION
# What I did

Exposed `silent` bool parameter to Account.transfer() which will pass it on to TransactionReceipt.
Setting silent = True will suppress any console output for the transaction.

Related issue: #467

### How I did it
Exposed the parameter and added all the necessary tests and docs.

### How to verify it
Run `test_silent_mode` or in brownie console: `a[0].transfer(a[1], "1 ether", silent = True)` should produce no console output.

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [x] I have included test cases
- [x] I have updated the documentation
- [x] I have added an entry to the changelog
