### PR TITLE
feat: allow disabling warnings when using brownie test

### DIFF
--- a/brownie/_cli/test.py
+++ b/brownie/_cli/test.py
@@ -28,6 +28,7 @@ Pytest Options:
   --durations [num]        show slowest setup/test durations (num=0 for all)
   --exitfirst -x           Exit instantly on first error or failed test
   --verbose -v             Increase verbosity
+  --disable-warnings -w    Disable all warnings
 
 Help Options:
   --fixtures            Show a list of available fixtures


### PR DESCRIPTION
### What I did
Add `--disable-warnings` flag to `brownie test` - closes #471 

### How I did it
Added a `pytest_terminal_summary` hook point to remove all exceptions when the flag is active.

### How to verify it
Try it!