### PR TITLE
Expose nonce parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This changelog format is based on [Keep a Changelog](https://keepachangelog.com/
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/iamdefinitelyahuman/brownie)
+### Changed
+- Exposed `nonce` parameter to transfer and transact methods ([#485](https://github.com/iamdefinitelyahuman/brownie/pull/485))
 
 ## [1.8.2](https://github.com/iamdefinitelyahuman/brownie/tree/v1.8.2) - 2020-05-04
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/iamdefinitelyahuman/brownie)
 ### Changed
-- Exposed `nonce` parameter to transfer and transact methods ([#485](https://github.com/iamdefinitelyahuman/brownie/pull/485))
+- Exposed `nonce` parameter to deploy, transfer and transact methods ([488](https://github.com/iamdefinitelyahuman/brownie/pull/488))
 
 ## [1.8.2](https://github.com/iamdefinitelyahuman/brownie/tree/v1.8.2) - 2020-05-04
 ### Fixed

--- a/brownie/network/account.py
+++ b/brownie/network/account.py
@@ -232,6 +232,7 @@ class _PrivateKeyAccount(PublicKeyAccount):
         amount: int = 0,
         gas_limit: Optional[int] = None,
         gas_price: Optional[int] = None,
+        nonce: Optional[int] = None,
     ) -> Any:
         """Deploys a contract.
 
@@ -244,6 +245,7 @@ class _PrivateKeyAccount(PublicKeyAccount):
             amount: Amount of ether to send with transaction, in wei.
             gas_limit: Gas limit of the transaction.
             gas_price: Gas price of the transaction.
+            nonce: Nonce to use for the transaction.
 
         Returns:
             * Contract instance if the transaction confirms
@@ -260,7 +262,7 @@ class _PrivateKeyAccount(PublicKeyAccount):
                 {
                     "from": self.address,
                     "value": Wei(amount),
-                    "nonce": self.nonce,
+                    "nonce": nonce if nonce is not None else self.nonce,
                     "gasPrice": Wei(gas_price) or self._gas_price(),
                     "gas": Wei(gas_limit) or self._gas_limit(None, amount, data),
                     "data": HexBytes(data),
@@ -324,6 +326,7 @@ class _PrivateKeyAccount(PublicKeyAccount):
         amount: int = 0,
         gas_limit: Optional[int] = None,
         gas_price: Optional[int] = None,
+        nonce: Optional[int] = None,
         data: str = None,
         silent: bool = False,
     ) -> "TransactionReceipt":
@@ -335,6 +338,7 @@ class _PrivateKeyAccount(PublicKeyAccount):
             amount: Amount of ether to send, in wei.
             gas_limit: Gas limit of the transaction.
             gas_price: Gas price of the transaction.
+            nonce: Nonce to use for the transaction.
             data: Hexstring of data to include in transaction.
             silent: Toggles console verbosity.
 
@@ -345,7 +349,7 @@ class _PrivateKeyAccount(PublicKeyAccount):
         tx = {
             "from": self.address,
             "value": Wei(amount),
-            "nonce": self.nonce,
+            "nonce": nonce if nonce is not None else self.nonce,
             "gasPrice": Wei(gas_price) if gas_price is not None else self._gas_price(),
             "gas": Wei(gas_limit) or self._gas_limit(to, amount, data),
             "data": HexBytes(data or ""),

--- a/brownie/network/account.py
+++ b/brownie/network/account.py
@@ -326,8 +326,8 @@ class _PrivateKeyAccount(PublicKeyAccount):
         amount: int = 0,
         gas_limit: Optional[int] = None,
         gas_price: Optional[int] = None,
-        nonce: Optional[int] = None,
         data: str = None,
+        nonce: Optional[int] = None,
         silent: bool = False,
     ) -> "TransactionReceipt":
         """
@@ -366,7 +366,7 @@ class _PrivateKeyAccount(PublicKeyAccount):
         if rpc.is_active():
             undo_thread = threading.Thread(
                 target=rpc._add_to_undo_buffer,
-                args=(receipt, self.transfer, (to, amount, gas_limit, gas_price, data), {}),
+                args=(receipt, self.transfer, (to, amount, gas_limit, gas_price, data, None), {}),
                 daemon=True,
             )
             undo_thread.start()

--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -892,12 +892,7 @@ def _get_tx(owner: Optional[AccountsType], args: Tuple) -> Tuple:
     if args and isinstance(args[-1], dict):
         tx.update(args[-1])
         args = args[:-1]
-        for key, target in [
-            ("amount", "value"),
-            ("gas_limit", "gas"),
-            ("gas_price", "gasPrice"),
-            ("nonce", "nonce"),
-        ]:
+        for key, target in [("amount", "value"), ("gas_limit", "gas"), ("gas_price", "gasPrice")]:
             if key in tx:
                 tx[target] = tx[key]
     return args, tx

--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -222,10 +222,15 @@ class ContractConstructor:
         if not tx["from"]:
             raise AttributeError(
                 "No deployer address given. You must supply a tx dict"
-                " with a 'from' field as the last argument."
+                " as the last argument with a 'from' field."
             )
         return tx["from"].deploy(
-            self._parent, *args, amount=tx["value"], gas_limit=tx["gas"], gas_price=tx["gasPrice"]
+            self._parent,
+            *args,
+            amount=tx["value"],
+            gas_limit=tx["gas"],
+            gas_price=tx["gasPrice"],
+            nonce=tx["nonce"],
         )
 
     def _autosuggest(self) -> List:
@@ -785,13 +790,15 @@ class _ContractMethod:
         if not tx["from"]:
             raise AttributeError(
                 "Contract has no owner, you must supply a tx dict"
-                " with a 'from' field as the last argument."
+                " as the last argument with a 'from' field."
             )
+
         return tx["from"].transfer(
             self._address,
             tx["value"],
             gas_limit=tx["gas"],
             gas_price=tx["gasPrice"],
+            nonce=tx["nonce"],
             data=self.encode_input(*args),
         )
 
@@ -881,11 +888,16 @@ def _get_tx(owner: Optional[AccountsType], args: Tuple) -> Tuple:
         owner = None
 
     # seperate contract inputs from tx dict and set default tx values
-    tx = {"from": owner, "value": 0, "gas": None, "gasPrice": None}
+    tx = {"from": owner, "value": 0, "gas": None, "gasPrice": None, "nonce": None}
     if args and isinstance(args[-1], dict):
         tx.update(args[-1])
         args = args[:-1]
-        for key, target in [("amount", "value"), ("gas_limit", "gas"), ("gas_price", "gasPrice")]:
+        for key, target in [
+            ("amount", "value"),
+            ("gas_limit", "gas"),
+            ("gas_price", "gasPrice"),
+            ("nonce", "nonce"),
+        ]:
             if key in tx:
                 tx[target] = tx[key]
     return args, tx

--- a/docs/api-network.rst
+++ b/docs/api-network.rst
@@ -248,7 +248,7 @@ Account Methods
         >>> accounts[0].balance() == "100 ether"
         True
 
-.. py:classmethod:: Account.deploy(contract, *args, amount=None, gas_limit=None, gas_price=None)
+.. py:classmethod:: Account.deploy(contract, *args, amount=None, gas_limit=None, gas_price=None, nonce=None)
 
     Deploys a contract.
 
@@ -257,6 +257,7 @@ Account Methods
     * ``amount``: Amount of ether to send with the transaction. The given value is converted to :func:`Wei <brownie.convert.datatypes.Wei>`.
     * ``gas_limit``: Gas limit for the transaction. The given value is converted to :func:`Wei <brownie.convert.datatypes.Wei>`. If none is given, the price is set using ``eth_estimateGas``.
     * ``gas_price``: Gas price for the transaction. The given value is converted to :func:`Wei <brownie.convert.datatypes.Wei>`. If none is given, the price is set using ``eth_gasPrice``.
+    * ``nonce``: Nonce for the transaction. If none is given, the nonce is set using ``eth_getTransactionCount``.
 
     Returns a :func:`Contract <brownie.network.contract.Contract>` instance upon success. If the transaction reverts or you do not wait for a confirmation, a :func:`TransactionReceipt <brownie.network.transaction.TransactionReceipt>` is returned instead.
 
@@ -293,7 +294,7 @@ Account Methods
         >>> accounts[0].estimate_gas(accounts[1], "1 ether")
         21000
 
-.. py:classmethod:: Account.transfer(self, to=None, amount=0, gas_limit=None, gas_price=None, data=None, silent=False)
+.. py:classmethod:: Account.transfer(self, to=None, amount=0, gas_limit=None, gas_price=None, data=None, nonce=None, silent=False)
 
     Broadcasts a transaction from this account.
 
@@ -302,6 +303,7 @@ Account Methods
     * ``gas_limit``: Gas limit for the transaction. The given value is converted to :func:`Wei <brownie.convert.datatypes.Wei>`. If none is given, the price is set using ``eth_estimateGas``.
     * ``gas_price``: Gas price for the transaction. The given value is converted to :func:`Wei <brownie.convert.datatypes.Wei>`. If none is given, the price is set using ``eth_gasPrice``.
     * ``data``: Transaction data hexstring.
+    * ``nonce``: Nonce for the transaction. If none is given, the nonce is set using ``eth_getTransactionCount``.
     * ``silent``: Toggles console verbosity. If ``True`` is given, suppresses all console output for this transaction.
 
     Returns a :func:`TransactionReceipt <brownie.network.transaction.TransactionReceipt>` instance.

--- a/docs/core-contracts.rst
+++ b/docs/core-contracts.rst
@@ -143,8 +143,9 @@ When executing a transaction to a contract, you can optionally include a :py:cla
     * ``gas_limit``: The amount of gas provided for transaction execution, in wei. If not given, the gas limit is determined using :meth:`web3.eth.estimateGas <web3.eth.Eth.estimateGas>`.
     * ``gas_price``: The gas price for the transaction, in wei. If not given, the gas price is set according to :attr:`web3.eth.gasPrice <web3.eth.Eth.gasPrice>`.
     * ``amount``: The amount of Ether to include with the transaction, in wei.
+    * ``nonce``: The nonce for the transaction. If not given, the nonce is set according to :meth:`web3.eth.getTransactionCount <web3.eth.Eth.getTransactionCount>`.
 
-All integer values can also be given as strings that will be converted by :func:`Wei <brownie.convert.datatypes.Wei>`.
+All currency integer values can also be given as strings that will be converted by :func:`Wei <brownie.convert.datatypes.Wei>`.
 
 .. note::
 

--- a/tests/network/account/test_account_deploy.py
+++ b/tests/network/account/test_account_deploy.py
@@ -92,6 +92,32 @@ def test_gas_limit_config(BrownieTester, accounts, config):
     assert tx.gas_limit == 5000000
 
 
+def test_nonce_manual(BrownieTester, accounts):
+    """returns a Contract instance on successful deployment with the correct nonce"""
+    assert accounts[0].nonce == 0
+    c = accounts[0].deploy(BrownieTester, True, nonce=0)
+    assert type(c) == ProjectContract
+    assert accounts[0].nonce == 1
+    c = accounts[0].deploy(BrownieTester, True, nonce=1)
+    assert type(c) == ProjectContract
+
+
+def test_nonce_manual_on_revert_in_console(BrownieTester, accounts, console_mode):
+    """returns a TransactionReceipt instance on reverted deployment with the correct nonce"""
+    accounts[0].transfer(accounts[1], "1 ether")
+    assert accounts[0].nonce == 1
+    tx = accounts[0].deploy(BrownieTester, False, nonce=1)
+    assert tx.nonce == 1
+
+
+@pytest.mark.parametrize("nonce", (1, -1, 15, False))
+def test_raises_on_wrong_nonce(BrownieTester, accounts, nonce):
+    """raises if invalid manual nonce is provided"""
+    assert accounts[0].nonce == 0
+    with pytest.raises(VirtualMachineError):
+        accounts[0].deploy(BrownieTester, False, nonce=nonce)
+
+
 def test_evm_version(BrownieTester, accounts, monkeypatch):
     monkeypatch.setattr("psutil.Popen.cmdline", lambda s: ["-k", "byzantium"])
     with pytest.raises(IncompatibleEVMVersion):

--- a/tests/network/account/test_account_transfer.py
+++ b/tests/network/account/test_account_transfer.py
@@ -156,6 +156,25 @@ def test_gas_limit_config(accounts, config):
     config.active_network["settings"]["gas_limit"] = False
 
 
+def test_nonce_manual(accounts):
+    """returns a Contract instance on successful deployment with the correct nonce"""
+    assert accounts[0].nonce == 0
+    tx = accounts[0].transfer(accounts[1], 1000, nonce=0)
+    assert tx.nonce == 0
+    assert accounts[0].nonce == 1
+    tx = accounts[0].transfer(accounts[1], 1000, nonce=1)
+    assert tx.nonce == 1
+
+
+@pytest.mark.parametrize("nonce", (1, -1, 15))
+def test_raises_on_wrong_nonce(accounts, nonce):
+    """raises if invalid manual nonce is provided"""
+    assert accounts[0].nonce == 0
+    with pytest.raises(VirtualMachineError):
+        tx = accounts[0].transfer(accounts[1], 1000, nonce=nonce)
+        assert tx.nonce == nonce
+
+
 def test_data(accounts):
     """transaction data is set correctly"""
     tx = accounts[0].transfer(accounts[1], 1000)

--- a/tests/network/contract/test_contracttx.py
+++ b/tests/network/contract/test_contracttx.py
@@ -142,6 +142,22 @@ def test_gas_limit_config(tester, accounts, config):
     config.active_network["settings"]["gas_limit"] = False
 
 
+def test_nonce_manual(tester, accounts):
+    """call is successful when correct nonce is specified"""
+    nonce = accounts[0].nonce
+    tx = tester.doNothing({"from": accounts[0], "nonce": nonce})
+    assert tx.nonce == nonce
+
+
+@pytest.mark.parametrize("nonce_offset", (-1, 1, 15))
+def test_raises_on_invalid_nonce_manual(tester, accounts, nonce_offset):
+    """raises if invalid nonce is specified"""
+    nonce = accounts[0].nonce
+    with pytest.raises(VirtualMachineError):
+        tx = tester.doNothing({"from": accounts[0], "nonce": nonce + nonce_offset})
+        assert tx.nonce == nonce + nonce_offset
+
+
 def test_repr(tester):
     repr(tester.revertStrings)
 


### PR DESCRIPTION
### What I did

-  changed transfer, deploy and transact functionality to expose the nonce parameter
-  minor clarification in error messages
-  added test cases for manual nonce

Related issue: #484

### How I did it

Added nonce as kwarg or dict element when creating a transaction. E.g.:
accounts[0].transfer(accounts[1], nonce=5)
tester.doNothing({"from": accounts[0], "nonce": 5})

### How to verify it

run tests

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [x] I have included test cases
- [x] I have updated the documentation
- [x] I have added an entry to the changelog
