### PR TITLE
fix: do not install solc 0.4.x on OSX in Contract.from_explorer

### DIFF
--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -3,6 +3,7 @@
 import json
 import os
 import re
+import sys
 import warnings
 from pathlib import Path
 from textwrap import TextWrapper
@@ -11,6 +12,7 @@ from urllib.parse import urlparse
 
 import eth_abi
 import requests
+import solcx
 from eth_utils import remove_0x_prefix
 from hexbytes import HexBytes
 from semantic_version import Version
@@ -618,7 +620,12 @@ class Contract(_DeployedContractBase):
             version = Version(data["result"][0]["CompilerVersion"].lstrip("v")).truncate()
         except Exception:
             version = Version("0.0.0")
-        if version < Version("0.4.22"):
+        if version < Version("0.4.22") or (
+            # special case for OSX because installing 0.4.x versions is problematic
+            sys.platform == "darwin"
+            and version < Version("0.5.0")
+            and f"v{version}" not in solcx.get_installed_solc_versions()
+        ):
             if not silent:
                 warnings.warn(
                     f"{address}: target compiler '{data['result'][0]['CompilerVersion']}' is "

--- a/tests/network/contract/test_contract.py
+++ b/tests/network/contract/test_contract.py
@@ -168,9 +168,21 @@ def test_from_explorer_only_abi(network):
 
 def test_from_explorer_pre_422(network):
     network.connect("mainnet")
-    contract = Contract.from_explorer("0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2")
 
+    # MKR, compiler version 0.4.18
+    contract = Contract.from_explorer("0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2")
     assert contract._name == "DSToken"
+    assert "pcMap" not in contract._build
+
+
+def test_from_explorer_osx_pre_050(network, monkeypatch):
+    network.connect("mainnet")
+    monkeypatch.setattr("sys.platform", "darwin")
+    installed = ["v0.5.8", "v0.5.7"]
+    monkeypatch.setattr("solcx.get_installed_solc_versions", lambda: installed)
+
+    # chainlink, compiler version 0.4.24
+    contract = Contract.from_explorer("0xf79d6afbb6da890132f9d7c355e3015f15f3406f")
     assert "pcMap" not in contract._build
 
 


### PR DESCRIPTION
### What I did
When using OSX, do not attempt to compile `0.4.x` contracts that are pulled from etherscan if the compiler version is not already installed.

Closes #487
