### PR TITLE
Sorted by gas amount used.

### DIFF
--- a/brownie/test/output.py
+++ b/brownie/test/output.py
@@ -32,8 +32,11 @@ def _print_gas_profile():
     # Formats and prints a gas profile report to the console
     print("\n\nGas Profile:")
     gas = TxHistory().gas_profile
-    for i in sorted(gas):
-        print(f"{i} -  avg: {gas[i]['avg']:.0f}  low: {gas[i]['low']}  high: {gas[i]['high']}")
+    sorted_gas = sorted(gas.items(), key=lambda value: value[1]["avg"], reverse=True)
+    for fn_name, values in sorted_gas:
+        print(
+            f"{fn_name} -  avg: {values['avg']:.0f}  low: {values['low']}  high: {values['high']}"
+        )
 
 
 def _print_coverage_totals(build, coverage_eval):

--- a/docs/api-test.rst
+++ b/docs/api-test.rst
@@ -181,7 +181,7 @@ Internal Methods
 
 .. py:method:: output._print_gas_profile()
 
-    Formats and prints a gas profile report.
+    Formats and prints a gas profile report. Report is sorted by gas amount used.
 
 .. py:method:: output._print_coverage_totals(build, coverage_eval)
 


### PR DESCRIPTION
### What I did

When gets a gas report, it is better to sort them by gas amount from large to small.

### How to verify it

Run test with argument `--gas`

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [x] I have included test cases
- [x] I have updated the documentation
- [x] I have added an entry to the changelog
