### PR TITLE
Feat etherscan api

### DIFF
--- a/brownie/project/compiler/__init__.py
+++ b/brownie/project/compiler/__init__.py
@@ -4,7 +4,7 @@ import json
 from copy import deepcopy
 from hashlib import sha1
 from pathlib import Path
-from typing import Dict, Optional, Union
+from typing import Dict, Optional
 
 from eth_utils import remove_0x_prefix
 from semantic_version import Version
@@ -49,7 +49,7 @@ def compile_and_format(
     solc_version: Optional[str] = None,
     optimize: bool = True,
     runs: int = 200,
-    evm_version: int = None,
+    evm_version: Optional[str] = None,
     silent: bool = True,
     allow_paths: Optional[str] = None,
     interface_sources: Optional[Dict[str, str]] = None,
@@ -143,7 +143,7 @@ def generate_input_json(
     contract_sources: Dict[str, str],
     optimize: bool = True,
     runs: int = 200,
-    evm_version: Union[int, str, None] = None,
+    evm_version: Optional[str] = None,
     language: str = "Solidity",
     interface_sources: Optional[Dict[str, str]] = None,
     remappings: Optional[list] = None,

--- a/docs/api-network.rst
+++ b/docs/api-network.rst
@@ -819,7 +819,7 @@ New ``Contract`` objects are created with one of the following class methods.
     Create a new ``Contract`` object from source code fetched from a block explorer such as `EtherScan <https://etherscan.io/>`_ or `Blockscout <https://blockscout.com/>`_.
 
     * ``address``: Address of the contract.
-    * ``as_proxy_for``: Address of the implementation contract, if ``address`` is a proxy contract. The generated object sends transactions to ``address``, but uses the ABI and NatSpec of ``as_proxy_for``.
+    * ``as_proxy_for``: Address of the implementation contract, if ``address`` is a proxy contract. The generated object sends transactions to ``address``, but uses the ABI and NatSpec of ``as_proxy_for``. This field is only required when the block explorer API does not provide an implementation address.
     * ``owner``: An optional :func:`Account <brownie.network.account.Account>` instance. If given, transactions to the contract are sent broadcasted from this account by default.
 
     If the deployed bytecode was generated using a compatible compiler version, Brownie will attempt to recompile it locally. If successful, most debugging functionality will be available.

--- a/tests/network/contract/test_contract.py
+++ b/tests/network/contract/test_contract.py
@@ -303,7 +303,8 @@ def test_as_proxy_for(network):
         as_proxy_for="0x97BD4Cc841FC999194174cd1803C543247a014fe",
     )
     implementation = Contract("0x97BD4Cc841FC999194174cd1803C543247a014fe")
-    assert original.abi != proxy.abi
+
+    assert original.abi == proxy.abi
     assert original.address == proxy.address
 
     assert proxy.abi == implementation.abi


### PR DESCRIPTION
### What I did
Update `Contract.from_explorer` with new Etherscan API

Closes #489 

### How I did it
* Compile with EVM ruleset indicated by API
* When API provides an implementation address, use it (if no `as_proxy_for` address is given)

### How to verify it
Run tests.