### PR TITLE
chore: add --full-trace flag to pytest config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,11 +28,12 @@ follow_imports = silent
 follow_imports = skip
 
 [tool:pytest]
-addopts = 
+addopts =
 	-p no:pytest-brownie
 	--cov brownie/
 	--cov-report term
 	--cov-report xml
 	--ignore tests/data/
+	--full-trace
 	-n auto
 


### PR DESCRIPTION
### What I did
Add the `--full-trace` flag when running pytest. This way the `__tracebackhide__` variable is ignored, and debugging is so much easier.