### PR TITLE
Allow path remappings in interfaces

### DIFF
--- a/brownie/project/compiler/solidity.py
+++ b/brownie/project/compiler/solidity.py
@@ -91,7 +91,11 @@ def install_solc(*versions: str) -> None:
 
 
 def get_abi(contract_source: str, allow_paths: Optional[str] = None) -> Dict:
-    """Given a contract source, returns a dict of {name: abi}"""
+    """
+    Given a contract source, returns a dict of {name: abi}
+
+    This function is deprecated in favor of `brownie.project.compiler.get_abi`
+    """
     version = find_best_solc_version({"<stdin>": contract_source})
     set_solc_version(version)
     compiled = solcx.compile_source(

--- a/brownie/project/compiler/vyper.py
+++ b/brownie/project/compiler/vyper.py
@@ -17,7 +17,11 @@ def get_version() -> Version:
 
 
 def get_abi(contract_source: str, name: str) -> Dict:
-    """Given a contract source and name, returns a dict of {name: abi}"""
+    """
+    Given a contract source and name, returns a dict of {name: abi}
+
+    This function is deprecated in favor of `brownie.project.compiler.get_abi`
+    """
     compiled = vyper_json.compile_json(
         {
             "language": "Vyper",

--- a/brownie/project/main.py
+++ b/brownie/project/main.py
@@ -285,13 +285,18 @@ class Project(_ProjectBase):
                     abi = json.loads(source)
                 elif path.suffix == ".vy":
                     try:
-                        abi = compiler.vyper.get_abi(source, name)[name]
+                        abi = compiler.get_abi(source, "Vyper", self._path.as_posix())["abi"]
                     except Exception:
                         # vyper interfaces do not convert to ABIs
                         # https://github.com/vyperlang/vyper/issues/1944
                         continue
                 else:
-                    abi = compiler.solidity.get_abi(source, allow_paths=self._path.as_posix())[name]
+                    abi = compiler.get_abi(
+                        source,
+                        "Solidity",
+                        allow_paths=self._path.as_posix(),
+                        remappings=self._compiler_config["solc"].get("remappings", []),
+                    )[name]
                 data = {
                     "abi": abi,
                     "contractName": name,

--- a/tests/project/compiler/test_solidity.py
+++ b/tests/project/compiler/test_solidity.py
@@ -206,7 +206,7 @@ def test_compile_empty():
 
 def test_get_abi():
     code = "pragma solidity 0.5.7; contract Foo { function baz() external returns (bool); }"
-    abi = compiler.solidity.get_abi(code)
+    abi = compiler.get_abi(code, "Solidity")
     assert len(abi) == 1
     assert abi["Foo"] == [
         {

--- a/tests/project/compiler/test_vyper.py
+++ b/tests/project/compiler/test_vyper.py
@@ -67,9 +67,9 @@ def test_compile_empty():
 
 def test_get_abi():
     code = "@public\ndef baz() -> bool: return True"
-    abi = compiler.vyper.get_abi(code, "Foo")
+    abi = compiler.get_abi(code, "Vyper")
     assert len(abi) == 1
-    assert abi["Foo"] == [
+    assert abi["abi"] == [
         {
             "name": "baz",
             "outputs": [{"type": "bool", "name": ""}],


### PR DESCRIPTION
### What I did
Allow use of packages and path remappings when compiling interfaces.

### How I did it
* Add the `project.compiler.get_abi` method. It uses the standard JSON input/output for compiling, similarly to how `project.compiler.compile_and_format` works.
* Mark the old `vyper.get_abi` and `solidity.get_abi` methods as deprecated.

### How to verify it
Run tests.
