### PR TITLE
fix: do not reset local environment on disconnect

### DIFF
--- a/brownie/network/main.py
+++ b/brownie/network/main.py
@@ -65,8 +65,6 @@ def disconnect(kill_rpc: bool = True) -> None:
     if kill_rpc and rpc.is_active():
         if rpc.is_child():
             rpc.kill()
-        else:
-            rpc.reset()
     web3.disconnect()
     _notify_registry(0)
 


### PR DESCRIPTION
### What I did
Do not reset when disconnecting from a development chain. Since removing the check preventing connection when the block height is non-zero (#461) this action makes less sense.