### PR TITLE
More interface compilation fixes

### DIFF
--- a/tests/project/compiler/test_interfaces.py
+++ b/tests/project/compiler/test_interfaces.py
@@ -1,0 +1,79 @@
+import json
+
+solc_interface = """
+pragma solidity ^0.6.0;
+interface Foo { event myEvent(); }
+interface Bar { event myOtherEvent(); }
+"""
+
+solc_import_interface = """
+pragma solidity ^0.6.0;
+import "../Foo.sol";
+interface Baz is Foo { event BazEvent(); }
+"""
+
+vyper_contract = """
+@public
+def foo() -> bool:
+    return True
+"""
+
+vyper_interface = """
+@public
+def foo() -> bool:
+    pass
+"""
+
+
+abi = [
+    {
+        "constant": True,
+        "inputs": [],
+        "name": "version",
+        "outputs": [{"internalType": "string", "name": "", "type": "string"}],
+        "payable": False,
+        "stateMutability": "view",
+        "type": "function",
+    }
+]
+
+
+def test_compile_interfaces(newproject):
+    with newproject._path.joinpath("interfaces/Foo.sol").open("w") as fp:
+        fp.write(solc_interface)
+    newproject.load()
+
+    assert hasattr(newproject.interface, "Foo")
+    assert hasattr(newproject.interface, "Bar")
+
+
+def test_interface_imports(newproject):
+    with newproject._path.joinpath("interfaces/Foo.sol").open("w") as fp:
+        fp.write(solc_interface)
+
+    newproject._path.joinpath("interfaces/baz").mkdir()
+    with newproject._path.joinpath("interfaces/baz/Baz.sol").open("w") as fp:
+        fp.write(solc_import_interface)
+    newproject.load()
+
+    assert hasattr(newproject.interface, "Baz")
+
+
+def test_json_interface(newproject):
+    with newproject._path.joinpath("interfaces/Foo.json").open("w") as fp:
+        json.dump(abi, fp)
+    newproject.load()
+
+    assert hasattr(newproject.interface, "Foo")
+
+
+def test_vyper_interface(newproject):
+    with newproject._path.joinpath("interfaces/Foo.vy").open("w") as fp:
+        fp.write(vyper_contract)
+
+    with newproject._path.joinpath("interfaces/Bar.vy").open("w") as fp:
+        fp.write(vyper_interface)
+    newproject.load()
+
+    assert hasattr(newproject.interface, "Foo")
+    assert not hasattr(newproject.interface, "Bar")

--- a/tests/project/compiler/test_solidity.py
+++ b/tests/project/compiler/test_solidity.py
@@ -206,7 +206,7 @@ def test_compile_empty():
 
 def test_get_abi():
     code = "pragma solidity 0.5.7; contract Foo { function baz() external returns (bool); }"
-    abi = compiler.get_abi(code, "Solidity")
+    abi = compiler.solidity.get_abi(code)
     assert len(abi) == 1
     assert abi["Foo"] == [
         {

--- a/tests/project/compiler/test_vyper.py
+++ b/tests/project/compiler/test_vyper.py
@@ -67,9 +67,9 @@ def test_compile_empty():
 
 def test_get_abi():
     code = "@public\ndef baz() -> bool: return True"
-    abi = compiler.get_abi(code, "Vyper")
+    abi = compiler.vyper.get_abi(code, "Vyper")
     assert len(abi) == 1
-    assert abi["abi"] == [
+    assert abi["Vyper"] == [
         {
             "name": "baz",
             "outputs": [{"type": "bool", "name": ""}],

--- a/tests/project/packages/test_import.py
+++ b/tests/project/packages/test_import.py
@@ -44,7 +44,7 @@ def test_dependency_with_remapping(newproject):
     with newproject._path.joinpath("brownie-config.yaml").open("w") as fp:
         yaml.dump(config, fp)
 
-    remapped_code = """
+    remapped_contract = """
 pragma solidity ^0.5.0;
 
 import "token/Token.sol";
@@ -52,7 +52,19 @@ import "token/Token.sol";
 contract Foo is Token {}
     """
 
-    with newproject._path.joinpath("contracts/Test.sol").open("w") as fp:
-        fp.write(remapped_code)
+    remapped_interface = """
+pragma solidity ^0.5.0;
+
+import "token/Token.sol";
+
+interface Bar {}
+    """
+
+    with newproject._path.joinpath("contracts/Foo.sol").open("w") as fp:
+        fp.write(remapped_contract)
+
+    with newproject._path.joinpath("interfaces/Bar.sol").open("w") as fp:
+        fp.write(remapped_interface)
 
     newproject.load()
+    assert hasattr(newproject.interface, "Bar")


### PR DESCRIPTION
### What I did
More work on #495 - source files in subdirectories within `interfaces/` weren't compiling properly.

### How I Did it
All previous efforts were using streamlined compilation logic to handle one file at a time and only generate an ABI. This time I've used the same logic as actual contract compilation, so hopefully there won't be any further issues.

### How to Verify
Run tests. I added some new test cases.