### PR TITLE
Remove brownie-mix parametrized testing

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,14 +5,11 @@ import json
 import os
 import shutil
 import sys
-import time
-from base64 import b64encode
 from copy import deepcopy
 from pathlib import Path
 from typing import Dict, List
 
 import pytest
-import requests
 from _pytest.monkeypatch import MonkeyPatch
 from ethpm._utils.ipfs import dummy_ipfs_pin
 from ethpm.backends.ipfs import BaseIPFSBackend
@@ -86,25 +83,6 @@ def pytest_generate_tests(metafunc):
             params += list(itertools.product(versions, runs, ["0.5.0", "0.4.25", "0.4.22"]))
 
         metafunc.parametrize("evmtester", params, indirect=True)
-
-    # parametrize the browniemix fixture
-    if "browniemix" in metafunc.fixturenames and target in ("all", "pm"):
-        if os.getenv("GITHUB_TOKEN"):
-            auth = b64encode(os.getenv("GITHUB_TOKEN").encode()).decode()
-            headers = {"Authorization": "Basic {}".format(auth)}
-        else:
-            headers = None
-
-        for i in range(10):
-            data = requests.get("https://api.github.com/orgs/brownie-mix/repos", headers=headers)
-            if data.status_code == 200:
-                break
-            time.sleep(30)
-
-        if data.status_code != 200:
-            raise ConnectionError("Cannot connect to Github API")
-
-        metafunc.parametrize("browniemix", [i["name"] for i in data.json()])
 
 
 # travis cannot call github ethereum/solidity API, so this method is patched

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -113,6 +113,7 @@ def pytest_sessionstart():
     monkeypatch_session.setattr(
         "solcx.get_available_solc_versions",
         lambda: [
+            "v0.6.7",
             "v0.6.2",
             "v0.5.15",
             "v0.5.8",

--- a/tests/project/compiler/test_solidity.py
+++ b/tests/project/compiler/test_solidity.py
@@ -180,9 +180,9 @@ def test_find_solc_versions_install(find_version, msolc):
     find_version("^0.4.22", install_latest=True)
     assert msolc.pop() == "v0.4.25"
     find_version("^0.4.24 || >=0.5.10", install_needed=True)
-    assert msolc.pop() == "v0.6.2"
+    assert msolc.pop() == "v0.6.7"
     find_version(">=0.4.24", install_latest=True)
-    assert msolc.pop() == "v0.6.2"
+    assert msolc.pop() == "v0.6.7"
 
 
 def test_install_solc(msolc):

--- a/tests/project/test_brownie_mix.py
+++ b/tests/project/test_brownie_mix.py
@@ -8,9 +8,8 @@ import pytest
 from brownie.project.scripts import run
 
 
-# browniemix is parametrized with every mix repo from https://www.github.com/brownie-mix/
-def test_mixes(plugintesterbase, project, tmp_path, rpc, browniemix, package_test):
-    path = Path(project.from_brownie_mix(browniemix, tmp_path.joinpath("testmix")))
+def test_mix(plugintesterbase, project, tmp_path, rpc, package_test):
+    path = Path(project.from_brownie_mix("token", tmp_path.joinpath("testmix")))
     os.chdir(path)
 
     # tests should pass without fails or errors


### PR DESCRIPTION
### What I did
* bump solidity version in tests to `0.6.7`
* remove parametrized tests for brownie mixes

Mixes are now being tested via a weekly scheduled workflow. The `travis-mix` is still verified in the brownie test cases to make sure that the functionality for downloading mixes is working.

This is to address an issue with testing the new `aave-flashloan-mix` where the mix tests expect to use a forked mainnet.