### PR TITLE
TransactionReceipt.timestamp

### DIFF
--- a/brownie/network/transaction.py
+++ b/brownie/network/transaction.py
@@ -73,6 +73,8 @@ class TransactionReceipt:
         gas_used: Gas used
         input: Hexstring input data
         nonce: Transaction nonce
+        block_number: Block number this transaction was included in
+        timestamp: Timestamp of the block this transaction was included in
         txindex: Index of the transaction within the mined block
         contract_address: Address of contract deployed by the transaction
         logs: Raw transaction logs
@@ -269,6 +271,12 @@ class TransactionReceipt:
         if self._trace is None:
             self._expand_trace()
         return self._trace
+
+    @property
+    def timestamp(self) -> Optional[int]:
+        if self.status == -1:
+            return None
+        return web3.eth.getBlock(self.block_number)["timestamp"]
 
     def _await_confirmation(self, silent: bool) -> None:
         # await tx showing in mempool

--- a/docs/api-network.rst
+++ b/docs/api-network.rst
@@ -1982,6 +1982,17 @@ TransactionReceipt Attributes
         >>> tx.status
         1
 
+.. py:attribute:: TransactionReceipt.timestamp
+
+    The timestamp of the block that this transaction was included in.
+
+    .. code-block:: python
+
+        >>> tx
+        <Transaction object '0xac54b49987a77805bf6bdd78fb4211b3dc3d283ff0144c231a905afa75a06db0'>
+        >>> tx.timestamp
+        1588957325
+
 .. py:attribute:: TransactionReceipt.trace
 
     An expanded `transaction trace <https://github.com/ethereum/go-ethereum/wiki/Tracing:-Introduction#user-content-basic-traces>`_ structLog, returned from the `debug_traceTransaction <https://github.com/ethereum/go-ethereum/wiki/Management-APIs#user-content-debug_tracetransaction>`_ RPC endpoint. If you are using Infura this attribute is not available.

--- a/tests/network/transaction/test_attributes.py
+++ b/tests/network/transaction/test_attributes.py
@@ -104,6 +104,17 @@ def test_hash(tester):
     assert a == a
 
 
+def test_timestamp(accounts, web3):
+    tx = accounts[0].transfer(accounts[1], "1 ether")
+    assert tx.timestamp == web3.eth.getBlock(web3.eth.blockNumber)["timestamp"]
+
+
+def test_timestamp_pending(accounts, web3):
+    tx = accounts[0].transfer(accounts[1], "1 ether")
+    tx.status = -1
+    assert tx.timestamp is None
+
+
 def test_attribute_error(tester):
     tx = tester.doNothing()
     with pytest.raises(AttributeError):


### PR DESCRIPTION
### What I did
Expose the timestamp for a transaction as `TransactionReceipt.timestamp`

### How I did it
`timestamp` is a `@property` method that calls `web3.eth.getBlock` to obtain the timestamp.
