### PR TITLE
Improvements to OverloadedMethod

### DIFF
--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -773,14 +773,62 @@ class OverloadedMethod:
         return fn(*args)  # type: ignore
 
     def call(self, *args: Tuple) -> Any:
+        """
+        Call the contract method without broadcasting a transaction.
+
+        The specific function called is chosen based on the number of
+        arguments given. If more than one function exists with this number
+        of arguments, a `ValueError` is raised.
+
+        Arguments
+        ---------
+        *args:
+            Contract method inputs. You can optionally provide a
+            dictionary of transaction properties as the last arg.
+
+        Returns
+        -------
+            Contract method return value(s).
+        """
         fn = self._get_fn_from_args(args)
         return fn.call(*args)
 
-    def transact(self, *args: Tuple) -> Any:
+    def transact(self, *args: Tuple) -> TransactionReceiptType:
+        """
+        Broadcast a transaction that calls this contract method.
+
+        The specific function called is chosen based on the number of
+        arguments given. If more than one function exists with this number
+        of arguments, a `ValueError` is raised.
+
+        Arguments
+        ---------
+        *args
+            Contract method inputs. You can optionally provide a
+            dictionary of transaction properties as the last arg.
+
+        Returns
+        -------
+        TransactionReceipt
+            Object representing the broadcasted transaction.
+        """
         fn = self._get_fn_from_args(args)
         return fn.transact(*args)
 
     def encode_input(self, *args: Tuple) -> Any:
+        """
+        Generate encoded ABI data to call the method with the given arguments.
+
+        Arguments
+        ---------
+        *args
+            Contract method inputs
+
+        Returns
+        -------
+        str
+            Hexstring of encoded ABI data
+        """
         fn = self._get_fn_from_args(args)
         return fn.encode_input(*args)
 
@@ -826,14 +874,19 @@ class _ContractMethod:
         _print_natspec(self.natspec)
 
     def call(self, *args: Tuple) -> Any:
-        """Calls the contract method without broadcasting a transaction.
+        """
+        Call the contract method without broadcasting a transaction.
 
-        Args:
-            *args: Contract method inputs. You can optionally provide a
-                   dictionary of transaction properties as the last arg.
+        Arguments
+        ---------
+        *args:
+            Contract method inputs. You can optionally provide a
+            dictionary of transaction properties as the last arg.
 
-        Returns:
-            Contract method return value(s)."""
+        Returns
+        -------
+            Contract method return value(s).
+        """
 
         args, tx = _get_tx(self._owner, args)
         if tx["from"]:
@@ -846,14 +899,20 @@ class _ContractMethod:
         return self.decode_output(data)
 
     def transact(self, *args: Tuple) -> TransactionReceiptType:
-        """Broadcasts a transaction that calls this contract method.
+        """
+        Broadcast a transaction that calls this contract method.
 
-        Args:
-            *args: Contract method inputs. You can optionally provide a
-                   dictionary of transaction properties as the last arg.
+        Arguments
+        ---------
+        *args:
+            Contract method inputs. You can optionally provide a
+            dictionary of transaction properties as the last arg.
 
-        Returns:
-            TransactionReceipt instance."""
+        Returns
+        -------
+        TransactionReceipt
+            Object representing the broadcasted transaction.
+        """
 
         args, tx = _get_tx(self._owner, args)
         if not tx["from"]:
@@ -872,13 +931,19 @@ class _ContractMethod:
         )
 
     def encode_input(self, *args: Tuple) -> str:
-        """Returns encoded ABI data to call the method with the given arguments.
+        """
+        Generate encoded ABI data to call the method with the given arguments.
 
-        Args:
-            *args: Contract method inputs
+        Arguments
+        ---------
+        *args
+            Contract method inputs
 
-        Returns:
-            Hexstring of encoded ABI data."""
+        Returns
+        -------
+        str
+            Hexstring of encoded ABI data
+        """
         data = format_input(self.abi, args)
         types_list = get_type_strings(self.abi["inputs"])
         return self.signature + eth_abi.encode_abi(types_list, data).hex()
@@ -899,43 +964,63 @@ class _ContractMethod:
 
 
 class ContractTx(_ContractMethod):
+    """
+    A public payable or non-payable contract method.
 
-    """A public payable or non-payable contract method.
-
-    Args:
-        abi: Contract ABI specific to this method.
-        signature: Bytes4 method signature."""
+    Attributes
+    ----------
+    abi : dict
+        Contract ABI specific to this method.
+    signature : str
+        Bytes4 method signature.
+    """
 
     def __call__(self, *args: Tuple) -> TransactionReceiptType:
-        """Broadcasts a transaction that calls this contract method.
+        """
+        Broadcast a transaction that calls this contract method.
 
-        Args:
-            *args: Contract method inputs. You can optionally provide a
-                   dictionary of transaction properties as the last arg.
+        Arguments
+        ---------
+        *args:
+            Contract method inputs. You can optionally provide a
+            dictionary of transaction properties as the last arg.
 
-        Returns:
-            TransactionReceipt instance."""
+        Returns
+        -------
+        TransactionReceipt
+            Object representing the broadcasted transaction.
+        """
 
         return self.transact(*args)
 
 
 class ContractCall(_ContractMethod):
 
-    """A public view or pure contract method.
+    """
+    A public view or pure contract method.
 
-    Args:
-        abi: Contract ABI specific to this method.
-        signature: Bytes4 method signature."""
+    Attributes
+    ----------
+    abi : dict
+        Contract ABI specific to this method.
+    signature : str
+        Bytes4 method signature.
+    """
 
     def __call__(self, *args: Tuple) -> Callable:
-        """Calls the contract method without broadcasting a transaction.
+        """
+        Call the contract method without broadcasting a transaction.
 
-        Args:
-            *args: Contract method inputs. You can optionally provide a
-                   dictionary of transaction properties as the last arg.
+        Arguments
+        ---------
+        *args:
+            Contract method inputs. You can optionally provide a
+            dictionary of transaction properties as the last arg.
 
-        Returns:
-            Contract method return value(s)."""
+        Returns
+        -------
+            Contract method return value(s).
+        """
 
         if not CONFIG.argv["always_transact"]:
             return self.call(*args)

--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -721,13 +721,14 @@ class OverloadedMethod:
 
     def _add_fn(self, abi: Dict, natspec: Dict) -> None:
         fn = _get_method_object(self._address, abi, self._name, self._owner, natspec)
-        key = ",".join(i["type"] for i in abi["inputs"]).replace("256", "")
+        key = tuple(i["type"].replace("256", "") for i in abi["inputs"])
         self.methods[key] = fn
 
     def __getitem__(self, key: Union[Tuple, str]) -> "_ContractMethod":
-        if isinstance(key, tuple):
-            key = ",".join(key)
-        key = key.replace("256", "").replace(", ", ",")
+        if isinstance(key, str):
+            key = tuple(i.strip() for i in key.split(","))
+
+        key = tuple(i.replace("256", "") for i in key)
         return self.methods[key]
 
     def __repr__(self) -> str:

--- a/brownie/network/transaction.py
+++ b/brownie/network/transaction.py
@@ -403,7 +403,7 @@ class TransactionReceipt:
         contract = _find_contract(self.receiver)
         if contract:
             data = _get_memory(trace[-1], -1)
-            fn = getattr(contract, self.fn_name)
+            fn = contract.get_method_object(self.input)
             self._return_value = fn.decode_output(data)
 
     def _reverted_trace(self, trace: Sequence) -> None:

--- a/docs/api-network.rst
+++ b/docs/api-network.rst
@@ -1099,6 +1099,15 @@ OverloadedMethod
         >>> erc223.transfer['address', 'uint256', 'uint256']
         <ContractTx object 'transfer(address,uint256,uint256)'>
 
+    When a contract only contains one method with the given name and number of arguements, ``OverloadedMethod`` may be called directly. When more than one method is present, a ``ValueError`` is raised.
+
+    .. code-block:: python
+
+        >>> erc223.transfer(accounts[0], "1 ether")
+        Transaction sent: 0x8dbf15878104571669f9843c18afc40529305ddb842f94522094454dcde22186
+        ERC223.transfer confirmed - block: 2   gas used: 50985 (100.00%)
+        <Transaction object '0x8dbf15878104571669f9843c18afc40529305ddb842f94522094454dcde22186'>
+
 InterfaceContainer
 ------------------
 

--- a/tests/network/contract/test_contract.py
+++ b/tests/network/contract/test_contract.py
@@ -11,7 +11,6 @@ from brownie.network.contract import (
     Contract,
     ContractCall,
     ContractTx,
-    OverloadedMethod,
     ProjectContract,
     _DeployedContractBase,
 )
@@ -51,34 +50,6 @@ def test_namespace_collision(tester, build):
     )
     with pytest.raises(AttributeError):
         Contract.from_abi(None, tester.address, build["abi"])
-
-
-def test_overloaded(testproject, tester, build):
-    build["abi"].append(
-        {
-            "constant": False,
-            "inputs": [
-                {"name": "_to", "type": "address"},
-                {"name": "_value", "type": "uint256"},
-                {"name": "_test", "type": "uint256"},
-            ],
-            "name": "revertStrings",
-            "outputs": [{"name": "", "type": "bool"}],
-            "payable": False,
-            "stateMutability": "nonpayable",
-            "type": "function",
-        }
-    )
-    del testproject.BrownieTester[0]
-    c = Contract.from_abi(None, tester.address, build["abi"])
-    fn = c.revertStrings
-    assert type(fn) == OverloadedMethod
-    assert len(fn) == 2
-    assert type(fn["uint"]) == ContractTx
-    assert fn["address", "uint256", "uint256"] == fn["address, uint256, uint256"]
-    assert fn["uint"] == fn["uint256"]
-    assert fn["uint"] != fn["address, uint256, uint256"]
-    repr(fn)
 
 
 def test_set_methods(tester):

--- a/tests/network/contract/test_overloaded_method.py
+++ b/tests/network/contract/test_overloaded_method.py
@@ -1,0 +1,78 @@
+#!/usr/bin/python3
+
+import pytest
+
+from brownie.network.contract import ContractCall, ContractTx, OverloadedMethod
+from brownie.project import compile_source
+
+vyper_source = """
+@public
+@constant
+def foo(a: int128, b: int128 = 42) -> int128:
+    return a + b
+"""
+
+solidity_source = """
+pragma solidity ^0.5.0;
+
+contract OverloadedTester {
+    function foo(uint256 a) public view returns (bool) { return true; }
+    function foo(bool a) public returns (bool) { return a; }
+    function foo(uint256 a, uint256 b) public view returns (uint256) { return a+b; }
+}
+"""
+
+
+@pytest.fixture
+def vyper_tester(accounts):
+    container = compile_source(vyper_source).Vyper
+    yield container.deploy({"from": accounts[0]})
+
+
+@pytest.fixture
+def solc_tester(accounts):
+    container = compile_source(solidity_source).OverloadedTester
+    yield container.deploy({"from": accounts[0]})
+
+
+def test_objects(solc_tester):
+    assert isinstance(solc_tester.foo, OverloadedMethod)
+    assert len(solc_tester.foo) == 3
+    assert isinstance(solc_tester.foo.methods[("uint",)], ContractCall)
+    assert isinstance(solc_tester.foo.methods[("bool",)], ContractTx)
+
+
+def test_keys(solc_tester):
+    assert solc_tester.foo["uint"] == solc_tester.foo["uint256"]
+    assert solc_tester.foo["uint", "uint"] == solc_tester.foo["uint256, uint256"]
+    assert solc_tester.foo["uint"] != solc_tester.foo["bool"]
+
+
+def test_forwarding_methods(solc_tester):
+    foo = solc_tester.foo
+
+    assert foo(12, 13) == foo["uint,uint"](12, 13)
+    assert foo.call(12, 13) == foo["uint,uint"].call(12, 13)
+    assert foo.transact(12, 13).return_value == foo["uint,uint"].transact(12, 13).return_value
+    assert foo.encode_input(12, 13) == foo["uint,uint"].encode_input(12, 13)
+
+
+def test_call_raises(accounts, solc_tester):
+    with pytest.raises(ValueError):
+        solc_tester.foo()
+    with pytest.raises(ValueError):
+        solc_tester.foo(1)
+
+    # including a tx params dictionary should not affect the outcome
+    with pytest.raises(ValueError):
+        solc_tester.foo({"from": accounts[0]})
+    with pytest.raises(ValueError):
+        solc_tester.foo(1, {"from": accounts[0]})
+
+
+def test_vyper(vyper_tester):
+    assert isinstance(vyper_tester.foo, OverloadedMethod)
+    assert len(vyper_tester.foo) == 2
+
+    assert vyper_tester.foo(1) == 43
+    assert vyper_tester.foo(2, 2) == 4


### PR DESCRIPTION
### What I did
Allow calls to `OverloadedMethod` without specifying the function signature. Closes #348

### How I did it
When an overloaded method only has one function with a given number of arguments, do not require the signature to be explicitly declared.

### How to verify it
Run tests. I added test cases.
