### PR TITLE
Account.gas_used

### DIFF
--- a/brownie/network/account.py
+++ b/brownie/network/account.py
@@ -17,10 +17,13 @@ from brownie.convert import Wei, to_address
 from brownie.exceptions import IncompatibleEVMVersion, UnknownAccount, VirtualMachineError
 
 from .rpc import Rpc, _revert_register
+from .state import TxHistory
 from .transaction import TransactionReceipt
 from .web3 import _resolve_address, web3
 
 __tracebackhide__ = True
+
+history = TxHistory()
 rpc = Rpc()
 
 
@@ -196,6 +199,11 @@ class PublicKeyAccount:
         """Returns the current balance at the address, in wei."""
         balance = web3.eth.getBalance(self.address)
         return Wei(balance)
+
+    @property
+    def gas_used(self) -> int:
+        """Returns the cumulative gas amount paid from this account."""
+        return sum(i.gas_used for i in history.from_sender(self.address))
 
     @property
     def nonce(self) -> int:

--- a/docs/api-network.rst
+++ b/docs/api-network.rst
@@ -225,6 +225,15 @@ Account Attributes
         >>> accounts[0].address
         '0x7Ebaa12c5d1EE7fD498b51d4F9278DC45f8D627A'
 
+.. py:attribute:: Account.gas_used
+
+    The cumulative gas amount paid for transactions from this account.
+
+    .. code-block:: python
+
+        >>> accounts[0].gas_used
+        21000
+
 .. py:attribute:: Account.nonce
 
     The current nonce of the address.
@@ -232,7 +241,7 @@ Account Attributes
     .. code-block:: python
 
         >>> accounts[0].nonce
-        0
+        1
 
 Account Methods
 ***************

--- a/tests/network/account/test_account.py
+++ b/tests/network/account/test_account.py
@@ -19,3 +19,10 @@ def test_balance(accounts):
     balance = accounts[0].balance()
     assert type(balance) is Wei
     assert balance == "100 ether"
+
+
+def test_gas_paid(accounts):
+    accounts[0].transfer(accounts[1], 10000)
+    accounts[0].transfer(accounts[2], 10000)
+
+    assert accounts[0].gas_used == 42000


### PR DESCRIPTION
### What I did
Add the `Account.gas_used` attribute

Closes #515 

### How I did it
`gas_used` is a `@property` method that sums the `gas_used` attribute for all transactions sent from the given account.

### How to verify it
Run the tests. I added a new case.

