### PR TITLE
add failed tx's to undo buffer before raising

### DIFF
--- a/brownie/network/account.py
+++ b/brownie/network/account.py
@@ -299,7 +299,9 @@ class _PrivateKeyAccount(PublicKeyAccount):
             undo_thread.start()
 
         if receipt.status != 1:
+            receipt._raise_if_reverted()
             return receipt
+
         add_thread.join()
         return contract.at(receipt.contract_address)
 
@@ -378,7 +380,7 @@ class _PrivateKeyAccount(PublicKeyAccount):
                 daemon=True,
             )
             undo_thread.start()
-
+        receipt._raise_if_reverted()
         return receipt
 
 
@@ -458,4 +460,5 @@ def _raise_or_return_tx(exc: ValueError) -> Any:
     except SyntaxError:
         raise exc
     except Exception:
+        print("hrmmmmmm")
         raise VirtualMachineError(exc) from None


### PR DESCRIPTION
### What I did
Add failing transactions to the undo buffer prior to raising.

Fixes a bug during coverage evaluation when an `eth_call` reverts.

### How I did it
Move the raising logic out of `TransactionReceipt.__init__` and into a private method that is called after appending to the undo buffer.

### How to verify it
Run tests.
