### PR TITLE
Warn on direct import of `hypothesis.given`

### DIFF
--- a/brownie/exceptions.py
+++ b/brownie/exceptions.py
@@ -135,3 +135,7 @@ class BrownieEnvironmentWarning(Warning):
 
 class InvalidArgumentWarning(BrownieEnvironmentWarning):
     pass
+
+
+class BrownieTestWarning(Warning):
+    pass

--- a/brownie/test/managers/base.py
+++ b/brownie/test/managers/base.py
@@ -7,13 +7,14 @@ from py.path import local
 
 from brownie._config import CONFIG
 from brownie.project.scripts import _get_ast_hash
-from brownie.test import coverage, output
+from brownie.test import _apply_given_wrapper, coverage, output
 
 from .utils import convert_outcome
 
 
 class PytestBrownieBase:
     def __init__(self, config, project):
+        _apply_given_wrapper()
 
         self.config = config
         # required when brownie project is in a subfolder of another project


### PR DESCRIPTION
### What I did
Raise a warning when directly importing hypothesis.

Closes #525 

### How I did it
When the brownie plugin loads, monkeypatch `hypothesis.given` with a thin wrapper that raises a warning.

### How to verify it
Run tests.
