### PR TITLE
Use `web3.eth.generateGasPrice` for gas price

### DIFF
--- a/brownie/network/account.py
+++ b/brownie/network/account.py
@@ -223,7 +223,7 @@ class _PrivateKeyAccount(PublicKeyAccount):
     def _gas_price(self) -> Wei:
         gas_price = CONFIG.active_network["settings"]["gas_price"]
         if isinstance(gas_price, bool) or gas_price in (None, "auto"):
-            return web3.eth.gasPrice
+            return web3.eth.generateGasPrice()
         return Wei(gas_price)
 
     def _check_for_revert(self, tx: Dict) -> None:

--- a/brownie/network/web3.py
+++ b/brownie/network/web3.py
@@ -10,6 +10,7 @@ from ens import ENS
 from web3 import HTTPProvider, IPCProvider
 from web3 import Web3 as _Web3
 from web3 import WebsocketProvider
+from web3.gas_strategies.rpc import rpc_gas_price_strategy
 
 from brownie._config import CONFIG, _get_data_folder
 from brownie.convert import to_address
@@ -132,6 +133,7 @@ def _resolve_address(domain: str) -> str:
 
 
 web3 = Web3()
+web3.eth.setGasPriceStrategy(rpc_gas_price_strategy)
 
 try:
     with _get_path().open() as fp:


### PR DESCRIPTION
### What I did
Allow use of custom gas strategies via the web3 gas price API

### How I did it
* When determining gas price, use `web3.eth.generateGasPrice` if no value is given in the config.
* Set the default strategy to check `eth_gasPrice`

### How to verify it
Run tests.
