### PR TITLE
fix: allow wss connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This changelog format is based on [Keep a Changelog](https://keepachangelog.com/
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/iamdefinitelyahuman/brownie)
+### Changed
+- Allow connections to `wss://` endpoints ([#542](https://github.com/iamdefinitelyahuman/brownie/pull/542))
 
 ## [1.8.6](https://github.com/iamdefinitelyahuman/brownie/tree/v1.8.6) - 2020-05-19
 ### Added

--- a/brownie/network/web3.py
+++ b/brownie/network/web3.py
@@ -41,9 +41,9 @@ class Web3(_Web3):
                 return
         except OSError:
             pass
-        if uri[:3] == "ws:":
+        if uri.startswith("ws"):
             self.provider = WebsocketProvider(uri)
-        elif uri[:4] == "http":
+        elif uri.startswith("http"):
 
             self.provider = HTTPProvider(uri, {"timeout": timeout})
         else:


### PR DESCRIPTION
### What I did
Fix to allow wss connections. 
Tested by connecting to infura using wss endpoint.

Related issue: #541

### How I did it
see PR

### How to verify it

Replace host for the mainnet network in the `network-config.yaml` file with `host: wss://mainnet.infura.io/ws/v3/$WEB3_INFURA_PROJECT_ID`

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [x] I have updated the documentation
- [x] I have added an entry to the changelog
