### PR TITLE
Improved --gas report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/iamdefinitelyahuman/brownie)
 ### Changed
 - Allow connections to `wss://` endpoints ([#542](https://github.com/iamdefinitelyahuman/brownie/pull/542))
+- Improved `--gas` report ([#543](https://github.com/iamdefinitelyahuman/brownie/pull/543))
+
 
 ## [1.8.6](https://github.com/iamdefinitelyahuman/brownie/tree/v1.8.6) - 2020-05-19
 ### Added

--- a/docs/api-test.rst
+++ b/docs/api-test.rst
@@ -181,7 +181,7 @@ Internal Methods
 
 .. py:method:: output._print_gas_profile()
 
-    Formats and prints a gas profile report. Report is sorted by gas amount used.
+    Formats and prints a gas profile report. The report is grouped by contracts and functions are sorted by average gas used.
 
 .. py:method:: output._print_coverage_totals(build, coverage_eval)
 

--- a/docs/tests-pytest-intro.rst
+++ b/docs/tests-pytest-intro.rst
@@ -379,6 +379,33 @@ Once you are finished, type ``quit()`` to continue with the next test.
 
 See :ref:`Inspecting and Debugging Transactions <core-transactions>` for more information on Brownie's debugging functionality.
 
+
+
+Evaluating Gas Usage
+--------------------
+
+To generate a gas profile report, add the ``--gas`` flag:
+
+::
+
+    $ brownie test --gas
+
+When the tests complete, a report will display:
+
+::
+
+        Gas Profile:
+        Token <Contract>
+           ├─ constructor   -  avg: 1099591  low: 1099591  high: 1099591
+           ├─ transfer      -  avg:   43017  low:   43017  high:   43017
+           └─ approve       -  avg:   21437  low:   21437  high:   21437
+        Storage <Contract>
+           ├─ constructor   -  avg:  211445  low:  211445  high:  211445
+           └─ set           -  avg:   21658  low:   21658  high:   21658
+
+
+
+
 Evaluating Coverage
 -------------------
 

--- a/tests/test/plugin/test_output.py
+++ b/tests/test/plugin/test_output.py
@@ -5,10 +5,14 @@ from pathlib import Path
 from brownie.test import output
 
 test_source = """
-def test_stuff(BrownieTester, accounts):
+def test_stuff(BrownieTester, EVMTester, accounts):
     c = accounts[0].deploy(BrownieTester, True)
     print('oh hai', 'mark')
-    c.doNothing({'from': accounts[0]})"""
+    c.doNothing({'from': accounts[0]})
+    c.sendEth({'from': accounts[0]})
+    d = accounts[0].deploy(EVMTester)
+    d.modulusByZero(5, 1, {'from': accounts[0]})
+    """
 
 
 def test_print_gas(plugintester, mocker):


### PR DESCRIPTION
### What I did
grouped by contract
sorted by average gas
padded for table-like view

```
Gas Profile:
BrownieTester <Contract>
   ├─ constructor   -  avg: 1099591  low: 1099591  high: 1099591
   ├─ sendEth       -  avg:   23017  low:   23017  high:   23017
   └─ doNothing     -  avg:   21437  low:   21437  high:   21437
EVMTester <Contract>
   ├─ constructor   -  avg:  711445  low:  711445  high:  711445
   └─ modulusByZero -  avg:   21658  low:   21658  high:   21658
```

Closes #536

### How I did it

String formatting

### How to verify it
`python -m pytest tests/test/plugin/test_output.py::test_print_gas --target plugin -n 0 -s --no-cov`

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [x] I have included test cases
- [x] I have updated the documentation
- [x] I have added an entry to the changelog
