### PR TITLE
Windows interactive debugging fixes

### DIFF
--- a/brownie/_cli/console.py
+++ b/brownie/_cli/console.py
@@ -155,6 +155,12 @@ class Console(code.InteractiveConsole):
             accept_binding = key_bindings.get_bindings_for_keys(("right",))[0]
             key_bindings._bindings2.remove(accept_binding.handler)
 
+        # this is required because of a pytest conflict when using the debugging console
+        if sys.platform == "win32":
+            import colorama
+
+            colorama.init()
+
         super().__init__(locals_dict)
 
     # console dir method, for simplified and colorful output

--- a/brownie/test/managers/runner.py
+++ b/brownie/test/managers/runner.py
@@ -326,7 +326,7 @@ class PytestBrownieRunner(PytestBrownieBase):
 
             tw = TerminalWriter()
             report.longrepr.toterminal(tw)
-            location = report.location[0]
+            location = self._path(report.location[0])
 
             # find last traceback frame within the active test
             traceback = next(


### PR DESCRIPTION
### What I did
* Fix a path issue preventing the interactive debugger from working on Windows systems
* Fix a `colorama` issue on Windows related to the interactive debugger

### How I did it
* Properly convert the path using `BrowniePytestPlugin._path`, so that the lookup in `node_map` doesn't produce a `KeyError`
* Load and init `colorama` within the init process of `Console` to ensure it properly has an effect

### How to verify it
Load the interactive debugger on a Windows system.
