### PR TITLE
fix: recompile moved contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Allow connections to `wss://` endpoints ([#542](https://github.com/iamdefinitelyahuman/brownie/pull/542))
 - Improved `--gas` report ([#543](https://github.com/iamdefinitelyahuman/brownie/pull/543))
-
+- Fixed error on moving contracts ([#545](https://github.com/iamdefinitelyahuman/brownie/pull/545)) 
 
 ## [1.8.6](https://github.com/iamdefinitelyahuman/brownie/tree/v1.8.6) - 2020-05-19
 ### Added

--- a/brownie/project/main.py
+++ b/brownie/project/main.py
@@ -181,6 +181,9 @@ class Project(_ProjectBase):
                 if test_path.exists():
                     test_path.unlink()
                 continue
+            if not self._path.joinpath(build_json["sourcePath"]).exists():
+                path.unlink()
+                continue
             self._build._add(build_json)
 
         interface_hashes = {}


### PR DESCRIPTION
### What I did
Fixed FileNotFoundError when moving a contract source file.

Closes #539

### How I did it
Delete artifacts where no matching source is found and recompile the artifact.

### How to verify it
Move a contract to a different folder and compile the project, then check the new artifact.

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [x] I have added an entry to the changelog
