### PR TITLE
Return TransactionReceipt on selfdestructed deployment

### DIFF
--- a/brownie/network/contract.py
+++ b/brownie/network/contract.py
@@ -187,7 +187,11 @@ class ContractContainer(_ContractBase):
     def _add_from_tx(self, tx: TransactionReceiptType) -> None:
         tx._confirmed.wait()
         if tx.status:
-            self.at(tx.contract_address, tx.sender, tx)
+            try:
+                self.at(tx.contract_address, tx.sender, tx)
+            except ContractNotFound:
+                # if the contract self-destructed during deployment
+                pass
 
 
 class ContractConstructor:


### PR DESCRIPTION
### What I did
Return a `TransactionReceipt` when a deployment succeeds but the contract does not exist (self destructed during deployment).

Closes #537

