### PR TITLE
fix: apply timeout to all web3 connection types

### DIFF
--- a/brownie/network/web3.py
+++ b/brownie/network/web3.py
@@ -37,12 +37,12 @@ class Web3(_Web3):
         uri = _expand_environment_vars(uri)
         try:
             if Path(uri).exists():
-                self.provider = IPCProvider(uri)
+                self.provider = IPCProvider(uri, {"timeout": timeout})
                 return
         except OSError:
             pass
         if uri.startswith("ws"):
-            self.provider = WebsocketProvider(uri)
+            self.provider = WebsocketProvider(uri, {"timeout": timeout})
         elif uri.startswith("http"):
 
             self.provider = HTTPProvider(uri, {"timeout": timeout})


### PR DESCRIPTION
### What I did
Apply `timeout` to all types of `web3` connections.

### How to verify it
Run the tests.
