### PR TITLE
fix: check web3.eth.accounts when calling Accounts.at

### DIFF
--- a/brownie/network/account.py
+++ b/brownie/network/account.py
@@ -152,10 +152,15 @@ class Accounts(metaclass=_Singleton):
             Account instance.
         """
         address = _resolve_address(address)
-        try:
-            return next(i for i in self._accounts if i == address)
-        except StopIteration:
-            raise UnknownAccount(f"No account exists for {address}")
+        acct = next((i for i in self._accounts if i == address), None)
+
+        if acct is None and address in web3.eth.accounts:
+            acct = Account(address)
+            self._accounts.append(acct)
+
+        if acct:
+            return acct
+        raise UnknownAccount(f"No account exists for {address}")
 
     def remove(self, address: str) -> None:
         """Removes an account instance from the container.


### PR DESCRIPTION
### What I did
Check `web3.eth.accounts` when accessing an account via `Accounts.at` - useful if a new account was added from e.g. a hardware wallet being unlocked.

### How to verify it
Run tests.
