### PR TITLE
fix: web3 ipc timeout

### DIFF
--- a/brownie/network/web3.py
+++ b/brownie/network/web3.py
@@ -37,7 +37,7 @@ class Web3(_Web3):
         uri = _expand_environment_vars(uri)
         try:
             if Path(uri).exists():
-                self.provider = IPCProvider(uri, {"timeout": timeout})
+                self.provider = IPCProvider(uri, timeout=timeout)
                 return
         except OSError:
             pass


### PR DESCRIPTION
### What I did
Fix how `timeout` arg is provided to `IPCProvider`

### How to verify it
Connect to a client via IPC.
