### PR TITLE
VirtualMachineError fixes

### DIFF
--- a/brownie/exceptions.py
+++ b/brownie/exceptions.py
@@ -8,6 +8,8 @@ import yaml
 
 import brownie
 
+__tracebackhide__ = True
+
 # network
 
 
@@ -86,7 +88,7 @@ class VirtualMachineError(Exception):
             try:
                 txid, data = next((k, v) for k, v in exc["data"].items() if k.startswith("0x"))
             except StopIteration:
-                return
+                raise ValueError(exc["message"]) from None
 
             self.txid: str = txid
             self.revert_type: str = data["error"]

--- a/brownie/test/managers/runner.py
+++ b/brownie/test/managers/runner.py
@@ -54,12 +54,19 @@ class RevertContextManager:
 
     def __exit__(self, exc_type, exc_value, traceback):
         __tracebackhide__ = True
+
         if exc_type is None:
             raise AssertionError("Transaction did not revert") from None
+
         if exc_type is not VirtualMachineError:
-            raise exc_type(exc_value).with_traceback(traceback)
+            raise exc_type(exc_value) from None
+
         if self.revert_msg is None or self.revert_msg == exc_value.revert_msg:
             return True
+
+        if exc_value.revert_msg is None:
+            raise AssertionError("Transaction reverted, but no revert string was given") from None
+
         raise AssertionError(
             f"Unexpected revert string '{exc_value.revert_msg}'\n{exc_value.source}"
         ) from None

--- a/tests/network/account/test_account_deploy.py
+++ b/tests/network/account/test_account_deploy.py
@@ -111,12 +111,12 @@ def test_nonce_manual_on_revert_in_console(BrownieTester, accounts, console_mode
     assert tx.nonce == 1
 
 
-@pytest.mark.parametrize("nonce", (1, -1, 15, False))
+@pytest.mark.parametrize("nonce", (1, -1, 15))
 def test_raises_on_wrong_nonce(BrownieTester, accounts, nonce):
     """raises if invalid manual nonce is provided"""
     assert accounts[0].nonce == 0
-    with pytest.raises(VirtualMachineError):
-        accounts[0].deploy(BrownieTester, False, nonce=nonce)
+    with pytest.raises(ValueError):
+        accounts[0].deploy(BrownieTester, True, nonce=nonce)
 
 
 def test_evm_version(BrownieTester, accounts, monkeypatch):

--- a/tests/network/account/test_account_transfer.py
+++ b/tests/network/account/test_account_transfer.py
@@ -170,9 +170,8 @@ def test_nonce_manual(accounts):
 def test_raises_on_wrong_nonce(accounts, nonce):
     """raises if invalid manual nonce is provided"""
     assert accounts[0].nonce == 0
-    with pytest.raises(VirtualMachineError):
-        tx = accounts[0].transfer(accounts[1], 1000, nonce=nonce)
-        assert tx.nonce == nonce
+    with pytest.raises(ValueError):
+        accounts[0].transfer(accounts[1], 1000, nonce=nonce)
 
 
 def test_data(accounts):

--- a/tests/network/contract/test_contractcall.py
+++ b/tests/network/contract/test_contractcall.py
@@ -1,8 +1,6 @@
 #!/usr/bin/python3
 import pytest
 
-from brownie.exceptions import VirtualMachineError
-
 
 def test_attributes(accounts, tester):
     assert tester.getTuple._address == tester.address
@@ -55,16 +53,12 @@ def test_nonce_manual_transact(tester, accounts):
     assert accounts[0].nonce == nonce + 1
 
 
-@pytest.mark.parametrize("nonce_offset", (-1, 1, 15))
-def test_rasises_on_incorrect_nonce_manual_transact(tester, accounts, nonce_offset):
+@pytest.mark.parametrize("nonce", (-1, 1, 15))
+def test_rasises_on_incorrect_nonce_manual_transact(tester, accounts, nonce):
     """raises on incorrect manual nonce with transact"""
-    nonce = accounts[0].nonce
-    with pytest.raises(VirtualMachineError):
-        tx = tester.getTuple.transact(
-            accounts[0], {"from": accounts[0], "nonce": nonce + nonce_offset}
-        )
-        assert tx.nonce == nonce + nonce_offset
-        assert accounts[0].nonce == nonce
+    nonce += accounts[0].nonce
+    with pytest.raises(ValueError):
+        tester.getTuple.transact(accounts[0], {"from": accounts[0], "nonce": nonce})
 
 
 def test_tuples(tester, accounts):

--- a/tests/network/contract/test_contracttx.py
+++ b/tests/network/contract/test_contracttx.py
@@ -149,13 +149,12 @@ def test_nonce_manual(tester, accounts):
     assert tx.nonce == nonce
 
 
-@pytest.mark.parametrize("nonce_offset", (-1, 1, 15))
-def test_raises_on_invalid_nonce_manual(tester, accounts, nonce_offset):
+@pytest.mark.parametrize("nonce", (-1, 1, 15))
+def test_raises_on_invalid_nonce_manual(tester, accounts, nonce):
     """raises if invalid nonce is specified"""
-    nonce = accounts[0].nonce
-    with pytest.raises(VirtualMachineError):
-        tx = tester.doNothing({"from": accounts[0], "nonce": nonce + nonce_offset})
-        assert tx.nonce == nonce + nonce_offset
+    nonce += accounts[0].nonce
+    with pytest.raises(ValueError):
+        tester.doNothing({"from": accounts[0], "nonce": nonce})
 
 
 def test_repr(tester):


### PR DESCRIPTION
### What I did
* Improve handling of `VirtualMachineError` in `brownie.reverts`
* Raise `ValueError` when the returned RPC error does not contain a data field.

### How to verify it
Run tests.
