### PR TITLE
fix: ganache shift bug & geth depth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This changelog format is based on [Keep a Changelog](https://keepachangelog.com/
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/iamdefinitelyahuman/brownie)
+### Fixed
+- Geth Traces depth reduced ([#562](https://github.com/iamdefinitelyahuman/brownie/pull/562))
+- Ganache gasCost in traces (ganache bug) ([#562](https://github.com/iamdefinitelyahuman/brownie/pull/562))
 
 ## [1.8.9](https://github.com/iamdefinitelyahuman/brownie/tree/v1.8.9) - 2020-05-26
 ### Changed


### PR DESCRIPTION
### What I did

1. Distinguish if we have a ganache or geth trace and save to tx._trace_origin
2. Shift ganache gas costs by one step
3. Reduce depth of geth traces by 1
4. Added tx._call_cost = overhead cost to initiate the transaction

Related issue: #561 

### How I did it
see PR

### How to verify it
tx.trace

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [x] I have added an entry to the changelog
