### PR TITLE
catch ZombieProcess/NoSuchProcess during `rpc.attach`

### DIFF
--- a/brownie/network/rpc.py
+++ b/brownie/network/rpc.py
@@ -393,6 +393,10 @@ def _check_connections(proc: psutil.Process, laddr: Tuple) -> bool:
         return laddr in [i.laddr for i in proc.connections()]
     except psutil.AccessDenied:
         return False
+    except psutil.ZombieProcess:
+        return False
+    except psutil.NoSuchProcess:
+        return False
 
 
 def _validate_cmd_settings(cmd_settings: dict) -> dict:


### PR DESCRIPTION
### What I did

Caught `ZombieProcess` and `NoSuchProcess` exceptions that can be thrown during the process scan on OSX. 

Fixes #570

### How I did it

### How to verify it

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [ ] I have added an entry to the changelog

I tested this version of the code and it has indeed fixed the error I was seeing in #570. 